### PR TITLE
Fix footer fields

### DIFF
--- a/dev/.eslintrc.cjs
+++ b/dev/.eslintrc.cjs
@@ -8,6 +8,7 @@ module.exports = {
     "no-console": "warn",
     "no-multiple-empty-lines": "warn",
     "prefer-const": "warn",
+    "quotes": ["warn", "double"],
     "@typescript-eslint/no-floating-promises": "off",
   }
 }

--- a/dev/dev.js
+++ b/dev/dev.js
@@ -74,9 +74,15 @@ function init(testData) {
     }
     test.setConfig({
       title: "Sunrise & Sunset",
-      showAzimuth: true,
-      showElevation: true,
-      darkMode: settings.darkMode
+      fields: {
+        // sunrise: false,
+        // sunset: false,
+        // dawn: false,
+        // dusk: false,
+        // noon: false,
+        azimuth: true,
+        elevation: true
+      }
     });
 
     const tzOffset = testData[settings.date][settings.place]["tzOffset"];

--- a/src/components/horizonCard/HorizonCardFooter.ts
+++ b/src/components/horizonCard/HorizonCardFooter.ts
@@ -23,17 +23,17 @@ export class HorizonCardFooter {
       <div class="horizon-card-footer">
         <div class="horizon-card-field-row">
           ${
-  this.fields?.dawn !== undefined
+  this.fields?.dawn
     ? HelperFunctions.renderFieldElement(this.i18n, EHorizonCardI18NKeys.Dawn, this.times?.dawn)
     : HelperFunctions.nothing()
 }
           ${
-  this.fields?.noon !== undefined
+  this.fields?.noon
     ? HelperFunctions.renderFieldElement(this.i18n, EHorizonCardI18NKeys.Noon, this.times?.noon)
     : HelperFunctions.nothing()
 }
           ${
-  this.fields?.dusk !== undefined
+  this.fields?.dusk
     ? HelperFunctions.renderFieldElement(this.i18n, EHorizonCardI18NKeys.Dusk, this.times?.dusk)
     : HelperFunctions.nothing()
 }
@@ -41,12 +41,12 @@ export class HorizonCardFooter {
 
         <div class="horizon-card-field-row">
           ${
-  this.fields?.azimuth !== undefined
+  this.fields?.azimuth
     ? HelperFunctions.renderFieldElement(this.i18n, EHorizonCardI18NKeys.Azimuth, this.data?.azimuth)
     : HelperFunctions.nothing()
 }
           ${
-  this.fields?.elevation !== undefined
+  this.fields?.elevation
     ? HelperFunctions.renderFieldElement(this.i18n, EHorizonCardI18NKeys.Elevation, this.data?.elevation)
     : HelperFunctions.nothing()
 }

--- a/src/utils/HelperFunctions.ts
+++ b/src/utils/HelperFunctions.ts
@@ -16,6 +16,9 @@ export class HelperFunctions {
       display = i18n.formatDateAsTime(value)
     } else {
       display = value.toString()
+      if (translationKey === 'azimuth' || translationKey === 'elevation') {
+        display += '°'
+      }
     }
 
     return html`


### PR DESCRIPTION
Fixes the footer fields issue (always shown regardless of config), related to #21.

- Respect config for footer field (dawn, solar noon, dusk, azimuth, elevation) visibility
- Add degree symbol to azimuth and elevation

We definitely need more tests related to those.
