### PR TITLE
Update description for a good presentation in HACS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lovelace-horizon-card",
   "version": "1.0.0",
-  "description": "Home Assistant Horizon card based on Google Weather design",
+  "description": "Successor to 'Sun Card' - Information about the sun in a beautiful Google weather inspired design",
   "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lovelace-horizon-card",
   "version": "1.0.0",
-  "description": "Successor to 'Sun Card' - Information about the sun in a beautiful Google weather inspired design",
+  "description": "Successor to Sun Card - Visualize the position of the sun over the horizon",
   "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
I suggest to update the description, which will be shown here:

![](https://user-images.githubusercontent.com/2870104/225671830-75699cb0-98e3-4181-81cb-2d4ffc9f32bb.png)

Happy to discuss the exact wording. Let's have a reference to sun card in there, so people full-text-searching for sun can still find it. The info about being the successor might also be helpful and can be removed in a few months.
