### PR TITLE
Fix margins and font sizes

### DIFF
--- a/src/cardStyles.ts
+++ b/src/cardStyles.ts
@@ -17,7 +17,6 @@ export default css`
     --horizon-card-stop-dusk-color: #393b78;
 
     padding: 0.5rem;
-    font-size: 1.3rem;
     font-family: var(--primary-font-family);
   }
 
@@ -30,7 +29,7 @@ export default css`
   .horizon-card-field-row {
     display: flex;
     justify-content: space-around;
-    margin: 1rem 1.5rem 0 1.5rem;
+    margin-top: 1rem;
   }
 
   .horizon-card-text-container {
@@ -45,28 +44,34 @@ export default css`
 
   .horizon-card-field-value {
     color: var(--horizon-card-field-value-color);
+    font-size: 1.3em;
+    line-height: 1.1em;
   }
 
   .horizon-card-header {
     display: flex;
-    justify-content: space-between;
-    margin: 0 4rem 0 4rem;
+    justify-content: space-around;
+    margin-top: 1rem;
+    margin-bottom: -1rem;
   }
 
-  .horizon-card-header .horizon-card-field-value {
-    font-size: 1.85rem;
+  .horizon-card-header .horizon-card-text-container {
+    font-size: 1.3rem;
+  }
+
+  .horizon-card-footer {
+    margin-bottom: 1rem;
   }
 
   .horizon-card-title {
-    margin: 0.5rem 0.5rem 3rem 3rem;
-    font-size: 2rem;
-    font-weight: 500;
+    margin: 1rem 1rem 2rem 1rem;
+    font-size: 1.5rem;
     color: var(--horizon-card-primary);
   }
 
   .horizon-card-graph {
     shape-rendering="geometricPrecision";
-    margin: 2rem 0 2rem 0;
+    margin: 1rem 0 1rem 0;
   }
 
   .horizon-card-graph .sunInitialStop {


### PR DESCRIPTION
# Overview
Fix margins and font sizes, related to #21.

- Make things more compact, now the default config has the same dimensions as the last AitorDB release
- Better handling of spacing around things

As a result, now things fit and look better (my subjective opinion). What is objective though - even the long German words fit!

# Sun Card vs Horizon Card BEFORE this change
(Sun Card is left, Horizon Card is right)

## Widest
![sun-card-vs-horizon-before-wide-en](https://user-images.githubusercontent.com/4996703/227338676-b5be8547-3d8a-43e0-baa9-3a0ad980ec7d.png)
![sun-card-vs-horizon-before-wide-de](https://user-images.githubusercontent.com/4996703/227338717-f4773acf-6e57-4cfc-ac3f-fac177d7b8bf.png)

## Narrowest
![sun-card-vs-horizon-before-narrow-en](https://user-images.githubusercontent.com/4996703/227338433-396f950d-c8d0-40be-ab1d-0e35cc757b00.png)
![sun-card-vs-horizon-before-narrow-de](https://user-images.githubusercontent.com/4996703/227338473-bf1579cc-a19e-4d93-acf0-349cc628ecc3.png)

# Sun Card vs Horizon Card AFTER this change

## Widest
![sun-card-vs-horizon-after-wide-en](https://user-images.githubusercontent.com/4996703/227339064-fbff086d-37bf-4e93-a942-a5b08d7962ff.png)
![sun-card-vs-horizon-after-wide-de](https://user-images.githubusercontent.com/4996703/227340318-6d4dd4d2-e81a-40fb-9e1c-c0f630268527.png)

## Narrowest
![sun-card-vs-horizon-after-narrow-en](https://user-images.githubusercontent.com/4996703/227338888-ea7bbdc1-acc9-43ba-970a-d4ba544e3e06.png)
![sun-card-vs-horizon-after-narrow-de](https://user-images.githubusercontent.com/4996703/227338979-5efb1f3d-9b25-4f00-b30b-1dd740cd6cf4.png)
