### PR TITLE
Disable visual editor

### DIFF
--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -7,7 +7,6 @@ import { Constants } from '../../constants'
 import { EHorizonCardErrors, IHorizonCardConfig, THorizonCardData, THorizonCardTimes, TSunInfo } from '../../types'
 import { HelperFunctions } from '../../utils/HelperFunctions'
 import { I18N } from '../../utils/I18N'
-import { HorizonCardEditor } from '../horizonCardEditor'
 import { HorizonErrorContent } from '../HorizonErrorContent'
 import { HorizonCardContent } from './HorizonCardContent'
 
@@ -42,9 +41,10 @@ export class HorizonCard extends LitElement {
     this.processLastHass()
   }
 
-  static getConfigElement (): HTMLElement {
-    return document.createElement(HorizonCardEditor.cardType)
-  }
+  // Visual editor disabled because it's broken, see https://developers.home-assistant.io/blog/2022/02/18/paper-elements/
+  // static getConfigElement (): HTMLElement {
+  //   return document.createElement(HorizonCardEditor.cardType)
+  // }
 
   // called by HASS whenever config changes
   public setConfig (config: IHorizonCardConfig): void {

--- a/tests/unit/components/horizonCard/HorizonCard.spec.ts
+++ b/tests/unit/components/horizonCard/HorizonCard.spec.ts
@@ -2,7 +2,6 @@ import { HomeAssistant } from 'custom-card-helpers'
 import { css, CSSResult } from 'lit'
 
 import { HorizonCard } from '../../../../src/components/horizonCard'
-import { HorizonCardEditor } from '../../../../src/components/horizonCardEditor'
 import { Constants } from '../../../../src/constants'
 import { EHorizonCardErrors, IHorizonCardConfig, THorizonCardData } from '../../../../src/types'
 import { CustomSnapshotSerializer, TemplateResultTestHelper } from '../../../helpers/TestHelpers'
@@ -73,17 +72,18 @@ describe('HorizonCard', () => {
     })
   })
 
-  describe('getConfigElement', () => {
-    it('creates and return a horizon card config element', () => {
-      const expectedElement = document.createElement('div')
-      const createElementSpy = jest.spyOn(document, 'createElement').mockReturnValueOnce(expectedElement)
-      const result = HorizonCard.getConfigElement()
-
-      expect(result).toEqual(expectedElement)
-      expect(createElementSpy).toHaveBeenCalledTimes(1)
-      expect(createElementSpy).toHaveBeenCalledWith(HorizonCardEditor.cardType)
-    })
-  })
+  // Visual editor disabled because it's broken, see https://developers.home-assistant.io/blog/2022/02/18/paper-elements/
+  // describe('getConfigElement', () => {
+  //   it('creates and return a horizon card config element', () => {
+  //     const expectedElement = document.createElement('div')
+  //     const createElementSpy = jest.spyOn(document, 'createElement').mockReturnValueOnce(expectedElement)
+  //     const result = HorizonCard.getConfigElement()
+  //
+  //     expect(result).toEqual(expectedElement)
+  //     expect(createElementSpy).toHaveBeenCalledTimes(1)
+  //     expect(createElementSpy).toHaveBeenCalledWith(HorizonCardEditor.cardType)
+  //   })
+  // })
 
   describe('setConfig', () => {
     it('overrides old config with new values', () => {


### PR DESCRIPTION
Disable the visual editor for the card config as it's broken and unfixable in its current state, see #41 for more details.

