### PR TITLE
Add `getCardSize()`

### DIFF
--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -49,13 +49,19 @@ export class HorizonCard extends LitElement {
   public getCardSize (): number {
 		let height = 4 // Smallest possible card (only graph) is roughly 200px
 
-    // Each element of card (header, content, footer) adds roughly 50px to the height
+    // Each element of card (title, header, content, footer) adds roughly 50px to the height
+    if(this.config.title && this.config.title.length > 0) {
+      height += 1
+    }
+
     if(this.config.fields?.sunrise || this.config.fields?.sunset) {
       height += 1
     }
+
     if(this.config.fields?.dawn || this.config.fields?.noon || this.config.fields?.dusk) {
       height += 1
     }
+
     if(this.config.fields?.azimuth || this.config.fields?.elevation) {
       height += 1
     }

--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -42,6 +42,10 @@ export class HorizonCard extends LitElement {
     this.processLastHass()
   }
 
+  public getCardSize (): number {
+		return 6
+	}
+
   static getConfigElement (): HTMLElement {
     return document.createElement(HorizonCardEditor.cardType)
   }

--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -50,19 +50,19 @@ export class HorizonCard extends LitElement {
 		let height = 4 // Smallest possible card (only graph) is roughly 200px
 
     // Each element of card (title, header, content, footer) adds roughly 50px to the height
-    if(this.config.title && this.config.title.length > 0) {
+    if (this.config.title && this.config.title.length > 0) {
       height += 1
     }
 
-    if(this.config.fields?.sunrise || this.config.fields?.sunset) {
+    if (this.config.fields?.sunrise || this.config.fields?.sunset) {
       height += 1
     }
 
-    if(this.config.fields?.dawn || this.config.fields?.noon || this.config.fields?.dusk) {
+    if (this.config.fields?.dawn || this.config.fields?.noon || this.config.fields?.dusk) {
       height += 1
     }
 
-    if(this.config.fields?.azimuth || this.config.fields?.elevation) {
+    if (this.config.fields?.azimuth || this.config.fields?.elevation) {
       height += 1
     }
 

--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -41,8 +41,26 @@ export class HorizonCard extends LitElement {
     this.processLastHass()
   }
 
+  /**
+   * called by HASS to properly distribute card in lovelace view. It should return height
+   * of the card as a number where 1 is equivalent of 50 pixels.
+   * @see https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card/#api
+   */
   public getCardSize (): number {
-		return 6
+		let height = 4 // Smallest possible card (only graph) is roughly 200px
+
+    // Each element of card (header, content, footer) adds roughly 50px to the height
+    if(this.config.fields?.sunrise || this.config.fields?.sunset) {
+      height += 1
+    }
+    if(this.config.fields?.dawn || this.config.fields?.noon || this.config.fields?.dusk) {
+      height += 1
+    }
+    if(this.config.fields?.azimuth || this.config.fields?.elevation) {
+      height += 1
+    }
+
+    return height
 	}
 
   // Visual editor disabled because it's broken, see https://developers.home-assistant.io/blog/2022/02/18/paper-elements/


### PR DESCRIPTION
# Pull Request Template for Home Assistant / Lovelace Card Repository

## Overview

Hey! As per [dev docs](https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card?_highlight=getcardsize#api)

![image](https://user-images.githubusercontent.com/23432278/232341531-ece10fc1-18f1-40c9-96ff-b34ab583ced3.png)

This PR defines  `getCardSize()` function that helps Lovelace to set up cards automatically. It returns `6` since card is 300px in height:

![image](https://user-images.githubusercontent.com/23432278/232341489-cf0789f5-0958-45ea-8ca1-32b133cde408.png)

### Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

Please ensure that you have completed the following tasks before submitting your pull request:

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md) for this project.
- [x] I have tested my changes against the `dev` branch (or another appropriate branch) and verified that they are working as expected.
- [x] I have updated the documentation (if applicable) to reflect my changes.
- [x] My changes adhere to the repository's code style guidelines.
- [x] My changes do not introduce any breaking changes or unexpected behaviors.

## Related Issues / Pull Requests

None

## Additional Details

Nope
