### PR TITLE
Update it.json - Better and Shorter

### DIFF
--- a/src/assets/localization/languages/it.json
+++ b/src/assets/localization/languages/it.json
@@ -1,11 +1,11 @@
 {
-  "azimuth": "Azimuth",
+  "azimuth": "Azimut",
   "dawn": "Aurora",
   "dusk": "Crepuscolo",
   "elevation": "Elevazione",
-  "moonrise": "Sorgere della luna",
-  "moonset": "Tramonto della luna",
-  "noon": "Mezzogiorno solare",
+  "moonrise": "Levata",
+  "moonset": "Calata",
+  "noon": "Mezzogiorno",
   "sunrise": "Alba",
   "sunset": "Tramonto"
 }


### PR DESCRIPTION


# Corrections of some words in Italian.

## Overview

Corrections of some Italian words, and improvement of translations of `moonrise` and `moonset'

### Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe): Editing the Italian translation

## Additional Details

Alternatively, "Levata" and "Caduta" can be replaced by "Levata Lunare" and "Caduto Lunare" or "Alba Lunare" and "Tramonto lunare", respectively, but the first two are decisively better and do not break the UI.

## Example of Breaking UI:
![image](https://github.com/rejuvenate/lovelace-horizon-card/assets/26876994/4c8e8bcf-565c-4f83-ba71-1de60835b665)
