### PR TITLE
Disable default release-on-push action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: rymndhng/release-on-push-action@master
         id: release
         with:
-          bump_version_scheme: minor
+          bump_version_scheme: norelease
           use_github_release_notes: true
 
       - name: Log Release Version


### PR DESCRIPTION
I would prefer if all version bumps and releases are triggered explicitly by us, i.e. via the labels `release:minor` etc.
This change disables the minor bump by default.