### PR TITLE
Convert SunCalc to ESModule export

### DIFF
--- a/suncalc3/suncalc.js
+++ b/suncalc3/suncalc.js
@@ -164,7 +164,6 @@
  * @property {Date} [highest] - Date of the highest position, only avalílable if set and rise is not NaN
  */
 
-(function () {
     'use strict';
     // sun calculations are based on http://aa.quae.nl/en/reken/zonpositie.html formulas
 
@@ -1236,16 +1235,4 @@
         };
     };
 
-    // export as Node module / AMD module / browser variable
-    if (typeof exports === 'object' && typeof module !== 'undefined') {
-        module.exports = SunCalc;
-        // @ts-ignore
-    } else if (typeof define === 'function' && define.amd) {
-        // @ts-ignore
-        define(SunCalc);
-    } else {
-        // @ts-ignore
-        window.SunCalc = SunCalc;
-    }
-
-})();
+    export default SunCalc;


### PR DESCRIPTION
# Pull Request Template for Home Assistant / Lovelace Card Repository

## Overview

I am using this project as a submodule of my own HomeAssistant dashboard ([HomeBoard](https://github.com/samleatherdale/homeboard))

There is an issue with importing SunCalc with Vite, where because it's a CommonJS export within an IIFE, it doesn't get picked up and I get the following error:

`Uncaught SyntaxError: The requested module '/lovelace-horizon-card/suncalc3/suncalc.js' does not provide an export named 'default'`

I have updated this module to use ES module syntax, and that resolves the issue.

### Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [x] Refactoring
- [ ] Other (please describe):

## Checklist

Please ensure that you have completed the following tasks before submitting your pull request:

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md) for this project.
- [x] I have tested my changes against the `dev` branch (or another appropriate branch) and verified that they are working as expected.
- [x] I have updated the documentation (if applicable) to reflect my changes.
- [x] My changes adhere to the repository's code style guidelines.
- [x] My changes do not introduce any breaking changes or unexpected behaviors.

## Related Issues / Pull Requests

## Additional Details

Please provide any additional information that you feel is relevant to this pull request, such as screenshots, code snippets, or examples.
