### PR TITLE
Use current Node and Yarn version in PR workflow

### DIFF
--- a/.github/workflows/pr-build-and-test.yaml
+++ b/.github/workflows/pr-build-and-test.yaml
@@ -14,24 +14,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 19
+          cache: yarn
+          node-version-file: .nvmrc
 
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Lint
         run: yarn lint


### PR DESCRIPTION
# Pull Request Template for Home Assistant / Lovelace Card Repository

## Overview

Fixes the CI errors introduced in #152 

### Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Additional Details

The fix consist in a few changes:

- Update `actions/setup-node` to latest version.
- Use native support for caching in `actions/setup-node` so we don't to deal with the cache ourselves.
- Be sure it uses Node version from `.nvmrc`.
- Enable corepack, so we pick yarn version from `package.json`.


Tested locally with [`act`](https://github.com/nektos/act), seems to work fine. Will keep an eye on GH Actions results once this get approved. 