### PR TITLE
Fix type-only imports and Lit class-field shadowing for modern bundlers

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -45,6 +45,13 @@ module.exports = {
     "@typescript-eslint/lines-between-class-members": ["error", { exceptAfterSingleLine: true }],
     "@typescript-eslint/no-empty-function": ["off"],
     "@typescript-eslint/ban-ts-comment": ["warn"],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        prefer: "type-imports",
+        fixStyle: "separate-type-imports"
+      }
+    ],
     "@typescript-eslint/naming-convention": [
       "error",
       {

--- a/src/components/HorizonErrorContent.ts
+++ b/src/components/HorizonErrorContent.ts
@@ -1,7 +1,8 @@
-import { html, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html } from 'lit'
 
-import { EHorizonCardErrors } from '../types'
-import { I18N } from '../utils/I18N'
+import type { EHorizonCardErrors } from '../types'
+import type { I18N } from '../utils/I18N'
 
 export class HorizonErrorContent {
   private readonly i18n: I18N

--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -1,11 +1,14 @@
-import { HomeAssistant, round } from 'custom-card-helpers'
-import { CSSResult, html, LitElement, TemplateResult } from 'lit'
+import type { HomeAssistant } from 'custom-card-helpers'
+import { round } from 'custom-card-helpers'
+import type { CSSResult, TemplateResult } from 'lit'
+import { html, LitElement } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
 import { default as SunCalc } from 'suncalc3'
 
 import cardStyles from '../../cardStyles'
 import { Constants } from '../../constants'
 import type {
+  EHorizonCardErrors,
   IHorizonCardConfig,
   THorizonCardData,
   THorizonCardFields,
@@ -14,7 +17,6 @@ import type {
   TSunPosition,
   TSunTimes
 } from '../../types'
-import { EHorizonCardErrors } from '../../types'
 import { HelperFunctions } from '../../utils/HelperFunctions'
 import { I18N } from '../../utils/I18N'
 import { HorizonErrorContent } from '../HorizonErrorContent'

--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -5,15 +5,16 @@ import { default as SunCalc } from 'suncalc3'
 
 import cardStyles from '../../cardStyles'
 import { Constants } from '../../constants'
-import { EHorizonCardErrors } from '../../types'
 import type {
   IHorizonCardConfig,
+  THorizonCardData,
   THorizonCardFields,
   TMoonData,
   TMoonPosition,
   TSunPosition,
   TSunTimes
 } from '../../types'
+import { EHorizonCardErrors } from '../../types'
 import { HelperFunctions } from '../../utils/HelperFunctions'
 import { I18N } from '../../utils/I18N'
 import { HorizonErrorContent } from '../HorizonErrorContent'
@@ -26,19 +27,24 @@ export class HorizonCard extends LitElement {
   static readonly cardDescription = 'Custom card that display a graph to track the sun position and related events'
 
   @state()
-  private accessor config!: IHorizonCardConfig
+  private declare config: IHorizonCardConfig
 
   @state()
-  private accessor data = Constants.DEFAULT_CARD_DATA
+  private declare data: THorizonCardData
 
   @state()
-  private accessor error: EHorizonCardErrors | undefined
+  private declare error: EHorizonCardErrors | undefined
 
   private lastHass!: HomeAssistant
 
   private hasCalculated = false
 
   private wasDisconnected = false
+
+  constructor () {
+    super()
+    this.data = Constants.DEFAULT_CARD_DATA
+  }
 
   static get styles (): CSSResult {
     return cardStyles

--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -5,8 +5,8 @@ import { default as SunCalc } from 'suncalc3'
 
 import cardStyles from '../../cardStyles'
 import { Constants } from '../../constants'
-import {
-  EHorizonCardErrors,
+import { EHorizonCardErrors } from '../../types'
+import type {
   IHorizonCardConfig,
   THorizonCardFields,
   TMoonData,
@@ -26,13 +26,13 @@ export class HorizonCard extends LitElement {
   static readonly cardDescription = 'Custom card that display a graph to track the sun position and related events'
 
   @state()
-  private config!: IHorizonCardConfig
+  private accessor config!: IHorizonCardConfig
 
   @state()
-  private data = Constants.DEFAULT_CARD_DATA
+  private accessor data = Constants.DEFAULT_CARD_DATA
 
   @state()
-  private error: EHorizonCardErrors | undefined
+  private accessor error: EHorizonCardErrors | undefined
 
   private lastHass!: HomeAssistant
 

--- a/src/components/horizonCard/HorizonCardContent.ts
+++ b/src/components/horizonCard/HorizonCardContent.ts
@@ -1,6 +1,6 @@
 import { html, TemplateResult } from 'lit'
 
-import { IHorizonCardConfig,THorizonCardData } from '../../types'
+import type { IHorizonCardConfig, THorizonCardData } from '../../types'
 import { I18N } from '../../utils/I18N'
 import { HorizonCardFooter } from './HorizonCardFooter'
 import { HorizonCardGraph } from './HorizonCardGraph'

--- a/src/components/horizonCard/HorizonCardContent.ts
+++ b/src/components/horizonCard/HorizonCardContent.ts
@@ -1,7 +1,8 @@
-import { html, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html } from 'lit'
 
 import type { IHorizonCardConfig, THorizonCardData } from '../../types'
-import { I18N } from '../../utils/I18N'
+import type { I18N } from '../../utils/I18N'
 import { HorizonCardFooter } from './HorizonCardFooter'
 import { HorizonCardGraph } from './HorizonCardGraph'
 import { HorizonCardHeader } from './HorizonCardHeader'

--- a/src/components/horizonCard/HorizonCardFooter.ts
+++ b/src/components/horizonCard/HorizonCardFooter.ts
@@ -1,6 +1,5 @@
 import { html, nothing, TemplateResult } from 'lit'
 
-import { EHorizonCardI18NKeys } from '../../types'
 import type {
   IHorizonCardConfig,
   THorizonCardData,
@@ -8,6 +7,7 @@ import type {
   TMoonTimes,
   TSunTimes
 } from '../../types'
+import { EHorizonCardI18NKeys } from '../../types'
 import { HelperFunctions } from '../../utils/HelperFunctions'
 import { I18N } from '../../utils/I18N'
 

--- a/src/components/horizonCard/HorizonCardFooter.ts
+++ b/src/components/horizonCard/HorizonCardFooter.ts
@@ -1,7 +1,7 @@
 import { html, nothing, TemplateResult } from 'lit'
 
-import {
-  EHorizonCardI18NKeys,
+import { EHorizonCardI18NKeys } from '../../types'
+import type {
   IHorizonCardConfig,
   THorizonCardData,
   THorizonCardFields,

--- a/src/components/horizonCard/HorizonCardFooter.ts
+++ b/src/components/horizonCard/HorizonCardFooter.ts
@@ -1,4 +1,5 @@
-import { html, nothing, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html, nothing } from 'lit'
 
 import type {
   IHorizonCardConfig,
@@ -9,7 +10,7 @@ import type {
 } from '../../types'
 import { EHorizonCardI18NKeys } from '../../types'
 import { HelperFunctions } from '../../utils/HelperFunctions'
-import { I18N } from '../../utils/I18N'
+import type { I18N } from '../../utils/I18N'
 
 export class HorizonCardFooter {
   private readonly data: THorizonCardData

--- a/src/components/horizonCard/HorizonCardGraph.ts
+++ b/src/components/horizonCard/HorizonCardGraph.ts
@@ -1,7 +1,14 @@
 import { html, nothing, svg, TemplateResult } from 'lit'
 
 import { Constants } from '../../constants'
-import { IHorizonCardConfig, THorizonCardData, TMoonData, TMoonPosition, TSunData, TSunPosition } from '../../types'
+import type {
+  IHorizonCardConfig,
+  THorizonCardData,
+  TMoonData,
+  TMoonPosition,
+  TSunData,
+  TSunPosition
+} from '../../types'
 
 export class HorizonCardGraph {
   private readonly config: IHorizonCardConfig

--- a/src/components/horizonCard/HorizonCardGraph.ts
+++ b/src/components/horizonCard/HorizonCardGraph.ts
@@ -1,4 +1,5 @@
-import { html, nothing, svg, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html, nothing, svg } from 'lit'
 
 import { Constants } from '../../constants'
 import type {

--- a/src/components/horizonCard/HorizonCardHeader.ts
+++ b/src/components/horizonCard/HorizonCardHeader.ts
@@ -1,6 +1,7 @@
 import { html, nothing, TemplateResult } from 'lit'
 
-import { EHorizonCardI18NKeys, IHorizonCardConfig, THorizonCardData, THorizonCardFields, TSunTimes } from '../../types'
+import { EHorizonCardI18NKeys } from '../../types'
+import type { IHorizonCardConfig, THorizonCardData, THorizonCardFields, TSunTimes } from '../../types'
 import { HelperFunctions } from '../../utils/HelperFunctions'
 import { I18N } from '../../utils/I18N'
 

--- a/src/components/horizonCard/HorizonCardHeader.ts
+++ b/src/components/horizonCard/HorizonCardHeader.ts
@@ -1,7 +1,7 @@
 import { html, nothing, TemplateResult } from 'lit'
 
-import { EHorizonCardI18NKeys } from '../../types'
 import type { IHorizonCardConfig, THorizonCardData, THorizonCardFields, TSunTimes } from '../../types'
+import { EHorizonCardI18NKeys } from '../../types'
 import { HelperFunctions } from '../../utils/HelperFunctions'
 import { I18N } from '../../utils/I18N'
 
@@ -10,7 +10,7 @@ export class HorizonCardHeader {
   private readonly times: TSunTimes
   private readonly fields: THorizonCardFields
   private readonly i18n: I18N
-  private readonly southern_flip: boolean;
+  private readonly southern_flip: boolean
 
   constructor (config: IHorizonCardConfig, data: THorizonCardData, i18n: I18N) {
     this.title = config.title
@@ -32,7 +32,7 @@ export class HorizonCardHeader {
     return html`<div class="horizon-card-title">${ this.title }</div>`
   }
 
-  private renderHeader(): TemplateResult {
+  private renderHeader (): TemplateResult {
     const sunrise = this.fields.sunrise
       ? HelperFunctions.renderFieldElement(this.i18n, EHorizonCardI18NKeys.Sunrise, this.times.sunrise)
       : nothing

--- a/src/components/horizonCard/HorizonCardHeader.ts
+++ b/src/components/horizonCard/HorizonCardHeader.ts
@@ -1,9 +1,10 @@
-import { html, nothing, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html, nothing } from 'lit'
 
 import type { IHorizonCardConfig, THorizonCardData, THorizonCardFields, TSunTimes } from '../../types'
 import { EHorizonCardI18NKeys } from '../../types'
 import { HelperFunctions } from '../../utils/HelperFunctions'
-import { I18N } from '../../utils/I18N'
+import type { I18N } from '../../utils/I18N'
 
 export class HorizonCardHeader {
   private readonly title?: string

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ import uk from './assets/localization/languages/uk.json'
 import ur from './assets/localization/languages/ur.json'
 import zh_Hans from './assets/localization/languages/zh-Hans.json'
 import zh_Hant from './assets/localization/languages/zh-Hant.json'
-import {
+import type {
   IHorizonCardConfig,
   SunCalcMoonPhase,
   THorizonCardData,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { LovelaceCardConfig, NumberFormat, TimeFormat } from 'custom-card-helpers'
+import type { LovelaceCardConfig, NumberFormat, TimeFormat } from 'custom-card-helpers'
 
 export type THorizonCardFields = {
   sunrise?: boolean

--- a/src/utils/HelperFunctions.ts
+++ b/src/utils/HelperFunctions.ts
@@ -1,8 +1,8 @@
 import { html, nothing, TemplateResult } from 'lit'
 
 import { Constants } from '../constants'
-import { EHorizonCardI18NKeys } from '../types'
 import type { TMoonPhase } from '../types'
+import { EHorizonCardI18NKeys } from '../types'
 import { I18N } from './I18N'
 
 type FieldValue = Date | number | string | undefined

--- a/src/utils/HelperFunctions.ts
+++ b/src/utils/HelperFunctions.ts
@@ -1,9 +1,10 @@
-import { html, nothing, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html, nothing } from 'lit'
 
 import { Constants } from '../constants'
 import type { TMoonPhase } from '../types'
 import { EHorizonCardI18NKeys } from '../types'
-import { I18N } from './I18N'
+import type { I18N } from './I18N'
 
 type FieldValue = Date | number | string | undefined
 

--- a/src/utils/HelperFunctions.ts
+++ b/src/utils/HelperFunctions.ts
@@ -1,7 +1,8 @@
 import { html, nothing, TemplateResult } from 'lit'
 
 import { Constants } from '../constants'
-import { EHorizonCardI18NKeys, TMoonPhase } from '../types'
+import { EHorizonCardI18NKeys } from '../types'
+import type { TMoonPhase } from '../types'
 import { I18N } from './I18N'
 
 type FieldValue = Date | number | string | undefined

--- a/src/utils/I18N.ts
+++ b/src/utils/I18N.ts
@@ -1,7 +1,7 @@
 import { formatNumber, FrontendLocaleData, LocalizeFunc, NumberFormat, TimeFormat } from 'custom-card-helpers'
 
 import { Constants } from '../constants'
-import { THorizonCardI18NKeys } from '../types'
+import type { THorizonCardI18NKeys } from '../types'
 
 export class I18N {
   private readonly localization: THorizonCardI18NKeys

--- a/src/utils/I18N.ts
+++ b/src/utils/I18N.ts
@@ -1,4 +1,5 @@
-import { formatNumber, FrontendLocaleData, LocalizeFunc, NumberFormat, TimeFormat } from 'custom-card-helpers'
+import type { FrontendLocaleData, LocalizeFunc, NumberFormat, TimeFormat } from 'custom-card-helpers'
+import { formatNumber } from 'custom-card-helpers'
 
 import { Constants } from '../constants'
 import type { THorizonCardI18NKeys } from '../types'

--- a/tests/helpers/TestHelpers.ts
+++ b/tests/helpers/TestHelpers.ts
@@ -1,5 +1,6 @@
-import { HomeAssistant } from 'custom-card-helpers'
-import { html, LitElement, TemplateResult } from 'lit'
+import type { HomeAssistant } from 'custom-card-helpers'
+import type { TemplateResult } from 'lit'
+import { html, LitElement } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
 
 @customElement('test-element')

--- a/tests/mocks/HorizonCardContent.ts
+++ b/tests/mocks/HorizonCardContent.ts
@@ -1,4 +1,5 @@
-import { html, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html } from 'lit'
 
 export class HorizonCardContent {
   public render (): TemplateResult {

--- a/tests/mocks/HorizonCardFooter.ts
+++ b/tests/mocks/HorizonCardFooter.ts
@@ -1,4 +1,5 @@
-import { html, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html } from 'lit'
 
 export class HorizonCardFooter {
   public render (): TemplateResult {

--- a/tests/mocks/HorizonCardGraph.ts
+++ b/tests/mocks/HorizonCardGraph.ts
@@ -1,4 +1,5 @@
-import { html, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html } from 'lit'
 
 export class HorizonCardGraph {
   public render (): TemplateResult {

--- a/tests/mocks/HorizonCardHeader.ts
+++ b/tests/mocks/HorizonCardHeader.ts
@@ -1,4 +1,5 @@
-import { html, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html } from 'lit'
 
 export class HorizonCardHeader {
   public render (): TemplateResult {

--- a/tests/mocks/HorizonErrorContent.ts
+++ b/tests/mocks/HorizonErrorContent.ts
@@ -1,4 +1,5 @@
-import { html, TemplateResult } from 'lit'
+import type { TemplateResult } from 'lit'
+import { html } from 'lit'
 
 export class HorizonErrorContent {
   public render (): TemplateResult {

--- a/tests/unit/components/HorizonErrorContent.spec.ts
+++ b/tests/unit/components/HorizonErrorContent.spec.ts
@@ -1,7 +1,7 @@
 import { NumberFormat, TimeFormat } from 'custom-card-helpers'
 
 import { HorizonErrorContent } from '../../../src/components/HorizonErrorContent'
-import { EHorizonCardErrors } from '../../../src/types'
+import type { EHorizonCardErrors } from '../../../src/types'
 import { I18N } from '../../../src/utils/I18N'
 import { TemplateResultTestHelper } from '../../helpers/TestHelpers'
 

--- a/tests/unit/components/horizonCard/HorizonCard.spec.ts
+++ b/tests/unit/components/horizonCard/HorizonCard.spec.ts
@@ -1,9 +1,10 @@
-import { HomeAssistant, NumberFormat, TimeFormat } from 'custom-card-helpers'
+import type { HomeAssistant} from 'custom-card-helpers'
+import { NumberFormat, TimeFormat } from 'custom-card-helpers'
 import { css, CSSResult } from 'lit'
 
 import { HorizonCard } from '../../../../src/components/horizonCard'
 import { Constants } from '../../../../src/constants'
-import { EHorizonCardErrors, IHorizonCardConfig, THorizonCardData, TMoonData, TSunTimes } from '../../../../src/types'
+import type { EHorizonCardErrors, IHorizonCardConfig, THorizonCardData, TMoonData, TSunTimes } from '../../../../src/types'
 import { I18N } from '../../../../src/utils/I18N'
 import { SaneHomeAssistant, TemplateResultTestHelper } from '../../../helpers/TestHelpers'
 import { default as SunCalcMock } from '../../../mocks/SunCalc'

--- a/tests/unit/components/horizonCard/HorizonCardContent.spec.ts
+++ b/tests/unit/components/horizonCard/HorizonCardContent.spec.ts
@@ -1,7 +1,7 @@
 import { NumberFormat, TimeFormat } from 'custom-card-helpers'
 
 import { HorizonCardContent } from '../../../../src/components/horizonCard'
-import { IHorizonCardConfig, THorizonCardData } from '../../../../src/types'
+import type { IHorizonCardConfig, THorizonCardData } from '../../../../src/types'
 import { I18N } from '../../../../src/utils/I18N'
 import { TemplateResultTestHelper } from '../../../helpers/TestHelpers'
 

--- a/tests/unit/components/horizonCard/HorizonCardFooter.spec.ts
+++ b/tests/unit/components/horizonCard/HorizonCardFooter.spec.ts
@@ -2,7 +2,7 @@ import { NumberFormat, TimeFormat } from 'custom-card-helpers'
 
 import { HorizonCardFooter } from '../../../../src/components/horizonCard'
 import { Constants } from '../../../../src/constants'
-import { IHorizonCardConfig, THorizonCardData } from '../../../../src/types'
+import type { IHorizonCardConfig, THorizonCardData } from '../../../../src/types'
 import { I18N } from '../../../../src/utils/I18N'
 import { TemplateResultTestHelper } from '../../../helpers/TestHelpers'
 

--- a/tests/unit/components/horizonCard/HorizonCardGraph.spec.ts
+++ b/tests/unit/components/horizonCard/HorizonCardGraph.spec.ts
@@ -1,6 +1,6 @@
 import { HorizonCardGraph } from '../../../../src/components/horizonCard'
 import { Constants } from '../../../../src/constants'
-import { IHorizonCardConfig, THorizonCardData } from '../../../../src/types'
+import type { IHorizonCardConfig, THorizonCardData } from '../../../../src/types'
 import { TemplateResultTestHelper } from '../../../helpers/TestHelpers'
 
 describe('HorizonCardGraph', () => {

--- a/tests/unit/components/horizonCard/HorizonCardHeader.spec.ts
+++ b/tests/unit/components/horizonCard/HorizonCardHeader.spec.ts
@@ -1,7 +1,7 @@
 import { NumberFormat, TimeFormat } from 'custom-card-helpers'
 
 import { HorizonCardHeader } from '../../../../src/components/horizonCard'
-import { IHorizonCardConfig, THorizonCardData, TSunData, TSunTimes } from '../../../../src/types'
+import type { IHorizonCardConfig, THorizonCardData, TSunData, TSunTimes } from '../../../../src/types'
 import { I18N } from '../../../../src/utils/I18N'
 import { TemplateResultTestHelper } from '../../../helpers/TestHelpers'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "experimentalDecorators": true,
+    "useDefineForClassFields": false,
     "allowSyntheticDefaultImports": true,
     "typeRoots": [
       "./src/types/custom",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,8 +25,7 @@
     "rootDir": ".",
     "allowJs": true,
     "removeComments": true,
-    "esModuleInterop": true,
-    "emitDecoratorMetadata": true,
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
## Overview

We consume this card as a **git submodule of the TypeScript source**, not via the published HACS/dist bundle. In our dashboard app ([Homeboard](https://github.com/SamLeatherdale/homeboard)) we import the Lit element directly and wrap it with `@lit/react`:

```ts
import { HorizonCard } from "../../lovelace-horizon-card/src/components/horizonCard"
```

That means Vite compiles this package’s `.ts` files as part of our app graph.

After upgrading that app to **Vite 8** (Rolldown + Oxc), two things broke:

1. **`MISSING_EXPORT` for type-only symbols** — mixed value/type imports such as `import { EHorizonCardErrors, IHorizonCardConfig, … } from '../../types'` were treated as runtime imports. Interfaces/types like `IHorizonCardConfig` are erased and are not real exports, so Rolldown failed the build/dev server.
2. **Lit class-field shadowing** — with `target: "esnext"`, TypeScript defaults `useDefineForClassFields` to `true`, so `@state()` fields were emitted as native instance fields. Those shadow Lit’s prototype accessors, and Lit throws for `config`, `data`, and `error` (see https://lit.dev/msg/class-field-shadowing).

This PR fixes both at the source, and adds lint/tsconfig guardrails so they don’t regress:

- Use `import type` for interfaces/types (and enforce with `@typescript-eslint/consistent-type-imports`).
- Declare Lit `@state()` fields with `declare` + constructor initialization, and set `useDefineForClassFields: false`.
- Remove unused `emitDecoratorMetadata` (the Babel/Rollup build does not emit design-time metadata).

The changes are compatible with Lit 2/3 and TypeScript 5. The normal HACS-installed JS bundle path is unaffected in intent; these fixes mainly help anyone compiling the TypeScript source with a modern bundler, and keep the project’s own TS/Lit settings correct.

### Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

Please ensure that you have completed the following tasks before submitting your pull request:

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md) for this project.
- [x] I have tested my changes against the `dev` branch (or another appropriate branch) and verified that they are working as expected.
- [x] I have updated the documentation (if applicable) to reflect my changes.
- [x] My changes adhere to the repository's code style guidelines.
- [x] My changes do not introduce any breaking changes or unexpected behaviors.

## Related Issues / Pull Requests

N/A

## Additional Details

Verified by consuming the card TypeScript source from a Vite 8 app: the previous `MISSING_EXPORT` errors for type-only symbols and Lit class-field-shadowing errors for `config`, `data`, and `error` no longer occur.

Also verified locally against this repository's CI steps: `yarn lint` (no errors; pre-existing non-null assertion warnings only), `yarn tsc --noEmit`, `yarn test` (10 suites / 695 tests), and `yarn build`.