### PR TITLE
Guard release upload step when no release is created (#159)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,7 @@ jobs:
           echo "Created release version: ${{ steps.release.outputs.version }}"
 
       - name: Upload JS card file to release
+        if: ${{ steps.release.outputs.version != '' }}
         uses: svenstaro/upload-release-action@v2
         with:
           overwrite: true


### PR DESCRIPTION
## Overview

The `Build & Release` workflow runs on every push to `main` and uses `release-on-push-action` with `bump_version_scheme: norelease`. That means a merge **without** a `release:patch|minor|major` label creates no release, and `steps.release.outputs.version` is empty. The subsequent **Upload JS card file to release** step is then invoked with an empty `tag` and fails:

```
##[error]Input required and not supplied: tag
```

This is what turned the run red after merging #181 (which had no release label). No release was published and nothing is broken for users — but every label-less merge leaves a failed workflow run.

## Change

Add a guard so the upload step is skipped when no release was created:

```yaml
- name: Upload JS card file to release
  if: ${{ steps.release.outputs.version != '' }}
```

Label-less merges to `main` now finish green; labelled merges (`release:*`) still create the release and upload `dist/lovelace-horizon-card.js` exactly as before.

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)