### PR TITLE
Add a Dockerized build/test environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+coverage
+.git
+.omc
+.DS_Store
+*.log
+npm-debug.log*
+.yarn/cache
+.yarn/install-state.gz

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+# Reproducible build/test environment for lovelace-horizon-card.
+# Everything (install, lint, test, build) runs inside the container so the
+# host never needs local node/yarn/library installs.
+#
+#   docker build -f docker/Dockerfile -t horizon-card-ci .
+#   docker run --rm horizon-card-ci                 # lint + test + build
+#   docker run --rm horizon-card-ci sh -lc "yarn test"
+#
+# syntax=docker/dockerfile:1
+FROM node:22-bookworm
+
+# Yarn 4 is pinned via package.json "packageManager"; corepack provisions it.
+RUN corepack enable
+
+WORKDIR /app
+
+# --- dependency layer (cached unless manifests or patches change) ---
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn/ .yarn/
+RUN yarn install --immutable
+
+# --- source ---
+COPY . .
+
+# Default: the same steps CI runs.
+CMD ["sh", "-lc", "yarn lint && yarn test && yarn build"]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Build the CI image and run a command inside it (default: lint + test + build).
+# Nothing is installed on the host; deps live only in the image.
+#
+#   docker/run.sh                      # lint + test + build
+#   docker/run.sh yarn test            # just the test suite
+#   docker/run.sh yarn build           # just the build
+#   docker/run.sh sh                   # interactive shell
+set -euo pipefail
+
+IMAGE="horizon-card-ci"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+docker build -f "$ROOT/docker/Dockerfile" -t "$IMAGE" "$ROOT"
+
+if [ "$#" -eq 0 ]; then
+  docker run --rm "$IMAGE"
+else
+  docker run --rm "$IMAGE" sh -lc "$*"
+fi


### PR DESCRIPTION
## Overview

Adds a reproducible, containerized build/test environment so contributors can run the full CI pipeline (`lint` + `test` + `build`) without installing node/yarn or any libraries on the host.

- `docker/Dockerfile` — Node 22 + Yarn 4 (via corepack, honoring `packageManager`), `yarn install --immutable` (applies the `suncalc3` patch), then the source.
- `docker/run.sh` — builds the image and runs the default pipeline; pass a command for a subset, e.g. `docker/run.sh yarn test`.
- `.dockerignore` — keeps `node_modules`/`dist`/`.git` out of the build context so host state never leaks in.

No source or CI-workflow changes; purely additive tooling.

## Verification
`bash docker/run.sh` on `main` → lint 0 errors (2 pre-existing warnings), 695 tests pass, build produces `dist/lovelace-horizon-card.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)