### PR TITLE
Prefer explicit card time_zone for display

### DIFF
--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -566,8 +566,8 @@ export class HorizonCard extends LitElement {
     // An explicit card `time_zone` always wins, for both computation and display.
     if (this.config.time_zone !== undefined) {
       display_time_zone = this.config.time_zone
-    // Since 2023.7, HA can show times in the local (for the browser) TZ or the server TZ.
     } else if (this.lastHass.locale['time_zone'] === 'local') {
+      // Since 2023.7, HA can show times in the local (for the browser) TZ or the server TZ.
       display_time_zone = Intl.DateTimeFormat().resolvedOptions().timeZone
     } else {
       // 'server' or missing value (older HA version)

--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -563,8 +563,11 @@ export class HorizonCard extends LitElement {
   private i18n (config: IHorizonCardConfig) {
     let display_time_zone
 
+    // An explicit card `time_zone` always wins, for both computation and display.
+    if (this.config.time_zone !== undefined) {
+      display_time_zone = this.config.time_zone
     // Since 2023.7, HA can show times in the local (for the browser) TZ or the server TZ.
-    if (this.lastHass.locale['time_zone'] === 'local') {
+    } else if (this.lastHass.locale['time_zone'] === 'local') {
       display_time_zone = Intl.DateTimeFormat().resolvedOptions().timeZone
     } else {
       // 'server' or missing value (older HA version)

--- a/tests/unit/components/horizonCard/HorizonCard.spec.ts
+++ b/tests/unit/components/horizonCard/HorizonCard.spec.ts
@@ -569,7 +569,8 @@ describe('HorizonCard', () => {
       number_format: NumberFormat.language
     } as IHorizonCardConfig
 
-    it('uses local time zone', () => {
+    it('uses the explicit config time zone over the local browser time zone', () => {
+      horizonCard.setConfig({ type: HorizonCard.cardType, time_zone: 'Europe/Sofia' } as IHorizonCardConfig)
       const hass = {
         ...SaneHomeAssistant,
       }
@@ -577,10 +578,11 @@ describe('HorizonCard', () => {
       horizonCard.hass = hass
 
       horizonCard['i18n'](config)
-      expect(I18N).toBeCalledWith('es', 'UTC', TimeFormat.language, NumberFormat.language, SaneHomeAssistant.localize)
+      expect(I18N).toBeCalledWith('es', 'Europe/Sofia', TimeFormat.language, NumberFormat.language, SaneHomeAssistant.localize)
     })
 
-    it('uses server time zone', () => {
+    it('uses the explicit config time zone over the server time zone', () => {
+      horizonCard.setConfig({ type: HorizonCard.cardType, time_zone: 'Europe/Sofia' } as IHorizonCardConfig)
       const hass = {
         ...SaneHomeAssistant,
       }
@@ -591,8 +593,26 @@ describe('HorizonCard', () => {
       expect(I18N).toBeCalledWith('es', 'Europe/Sofia', TimeFormat.language, NumberFormat.language, SaneHomeAssistant.localize)
     })
 
-    it('uses server time zone on older HASS', () => {
-      horizonCard.hass = SaneHomeAssistant
+    it('uses the local browser time zone when config has no time zone', () => {
+      horizonCard.setConfig({ type: HorizonCard.cardType } as IHorizonCardConfig)
+      const hass = {
+        ...SaneHomeAssistant,
+      }
+      hass.locale['time_zone'] = 'local'
+      horizonCard.hass = hass
+
+      horizonCard['i18n'](config)
+      expect(I18N).toBeCalledWith('es', 'UTC', TimeFormat.language, NumberFormat.language, SaneHomeAssistant.localize)
+    })
+
+    it('uses the server time zone when config has no time zone', () => {
+      horizonCard.setConfig({ type: HorizonCard.cardType } as IHorizonCardConfig)
+      const hass = {
+        ...SaneHomeAssistant,
+      }
+      // 'server' or a missing value (older HA version) both take this branch.
+      hass.locale['time_zone'] = 'server'
+      horizonCard.hass = hass
 
       horizonCard['i18n'](config)
       expect(I18N).toBeCalledWith('es', 'Europe/Sofia', TimeFormat.language, NumberFormat.language, SaneHomeAssistant.localize)

--- a/tests/unit/components/horizonCard/HorizonCard.spec.ts
+++ b/tests/unit/components/horizonCard/HorizonCard.spec.ts
@@ -573,6 +573,7 @@ describe('HorizonCard', () => {
       horizonCard.setConfig({ type: HorizonCard.cardType, time_zone: 'Europe/Sofia' } as IHorizonCardConfig)
       const hass = {
         ...SaneHomeAssistant,
+        locale: { ...SaneHomeAssistant.locale }
       }
       hass.locale['time_zone'] = 'local'
       horizonCard.hass = hass
@@ -582,21 +583,24 @@ describe('HorizonCard', () => {
     })
 
     it('uses the explicit config time zone over the server time zone', () => {
-      horizonCard.setConfig({ type: HorizonCard.cardType, time_zone: 'Europe/Sofia' } as IHorizonCardConfig)
+      // Distinct from the argument's 'Europe/Sofia' to prove the branch reads the raw config.
+      horizonCard.setConfig({ type: HorizonCard.cardType, time_zone: 'Asia/Tokyo' } as IHorizonCardConfig)
       const hass = {
         ...SaneHomeAssistant,
+        locale: { ...SaneHomeAssistant.locale }
       }
       hass.locale['time_zone'] = 'server'
       horizonCard.hass = hass
 
       horizonCard['i18n'](config)
-      expect(I18N).toBeCalledWith('es', 'Europe/Sofia', TimeFormat.language, NumberFormat.language, SaneHomeAssistant.localize)
+      expect(I18N).toBeCalledWith('es', 'Asia/Tokyo', TimeFormat.language, NumberFormat.language, SaneHomeAssistant.localize)
     })
 
     it('uses the local browser time zone when config has no time zone', () => {
       horizonCard.setConfig({ type: HorizonCard.cardType } as IHorizonCardConfig)
       const hass = {
         ...SaneHomeAssistant,
+        locale: { ...SaneHomeAssistant.locale }
       }
       hass.locale['time_zone'] = 'local'
       horizonCard.hass = hass
@@ -609,6 +613,7 @@ describe('HorizonCard', () => {
       horizonCard.setConfig({ type: HorizonCard.cardType } as IHorizonCardConfig)
       const hass = {
         ...SaneHomeAssistant,
+        locale: { ...SaneHomeAssistant.locale }
       }
       // 'server' or a missing value (older HA version) both take this branch.
       hass.locale['time_zone'] = 'server'


### PR DESCRIPTION
## Overview

When Home Assistant's profile time-zone setting is **"Local"**, the browser time zone was used unconditionally for displayed times, so an explicit card `time_zone:` never took effect for display — it only affected the computation (via `timeZone()`). Times shown were therefore inconsistent with the configured zone whenever a user relies on HA's "Local" display setting.

Resolves #70 and #166. (Fix suggested by @mmcgrath in #166.)

## Change

`i18n()` now lets an explicit `this.config.time_zone` win for both computation and display, falling back to the existing local/server/older-HA logic only when the card sets no time zone:

```ts
if (this.config.time_zone !== undefined) {
  display_time_zone = this.config.time_zone          // explicit card config wins
} else if (this.lastHass.locale['time_zone'] === 'local') {
  display_time_zone = Intl.DateTimeFormat().resolvedOptions().timeZone
} else {
  display_time_zone = config.time_zone               // server / older HA
}
```

Only the previously-broken **"explicit `time_zone` + HA=Local"** path changes; the default (no `time_zone`) and HA=Server paths are byte-identical to before.

**Scope note:** this aligns display with computation only for the explicit `time_zone` case. The unset-config + HA="Local" case keeps its existing split (display = browser, computation = server) and is out of scope here. (Deriving the *computation* zone from longitude for far-away `latitude`/`longitude` overrides is #71 — a separate follow-up.)

## Tests

Rewrote the three `i18n` unit tests to call `setConfig()` first (the new branch reads `this.config`) and to cover all four branches (explicit `time_zone` vs local/server, and no `time_zone` vs local/server), incl. a regression test asserting the config zone wins over the browser zone.

## Verification (in Docker)
`bash docker/run.sh` → lint 0 errors (2 pre-existing warnings), **716 tests** pass, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)