### PR TITLE
Derive sun/moon computation reference from longitude when scoped

### DIFF
--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -321,9 +321,13 @@ export class HorizonCard extends LitElement {
 
   private readSunTimes (now: Date, latitude: number, longitude: number, elevation: number): TSunTimes {
     const nowDayBefore = new Date(now.getTime() - Constants.MS_24_HOURS)
-    const sunTimesNow = SunCalc.getSunTimes(HelperFunctions.noonAtTimeZone(now, this.timeZone()),
+    const sunTimesNow = SunCalc.getSunTimes(this.useLongitudeForComputation()
+      ? HelperFunctions.noonAtLongitude(now, longitude)
+      : HelperFunctions.noonAtTimeZone(now, this.timeZone()),
       latitude, longitude, elevation, false, false, true)
-    const sunTimesDayBefore = SunCalc.getSunTimes(HelperFunctions.noonAtTimeZone(nowDayBefore, this.timeZone()),
+    const sunTimesDayBefore = SunCalc.getSunTimes(this.useLongitudeForComputation()
+      ? HelperFunctions.noonAtLongitude(nowDayBefore, longitude)
+      : HelperFunctions.noonAtTimeZone(nowDayBefore, this.timeZone()),
       latitude, longitude, elevation, false, false, true)
 
     const noonDelta = now.getTime() - sunTimesDayBefore.solarNoon.value.getTime()
@@ -437,7 +441,9 @@ export class HorizonCard extends LitElement {
     const azimuth = this.roundDegree(moonRawData.azimuthDegrees)
     const elevation = this.roundDegree(moonRawData.altitudeDegrees)
 
-    const moonRawTimes = SunCalc.getMoonTimes(HelperFunctions.midnightAtTimeZone(now, this.timeZone()),
+    const moonRawTimes = SunCalc.getMoonTimes(this.useLongitudeForComputation()
+      ? HelperFunctions.midnightAtLongitude(now, lon)
+      : HelperFunctions.midnightAtTimeZone(now, this.timeZone()),
       lat, lon, false, true)
 
     const moonPhase = Constants.MOON_PHASES[moonRawData.illumination.phase.id]
@@ -507,6 +513,14 @@ export class HorizonCard extends LitElement {
 
   private timeZone (): string {
     return this.config.time_zone ?? this.lastHass.config.time_zone
+  }
+
+  // Two independent axes: longitude drives the computation reference, time_zone drives display.
+  // Anchor the computation day to the location's solar day only when the user set an explicit
+  // longitude without a time_zone. Reads raw config (not the accessors, which always fall back
+  // to HA values) so every other setup stays byte-identical to before.
+  private useLongitudeForComputation (): boolean {
+    return this.config.longitude !== undefined && this.config.time_zone === undefined
   }
 
   private now (): Date {

--- a/src/utils/HelperFunctions.ts
+++ b/src/utils/HelperFunctions.ts
@@ -130,6 +130,23 @@ export class HelperFunctions {
     return tzDate
   }
 
+  public static noonAtLongitude (date: Date, longitude: number): Date {
+    return HelperFunctions.solarTimeAtLongitude(date, 12, longitude)
+  }
+
+  public static midnightAtLongitude (date: Date, longitude: number): Date {
+    return HelperFunctions.solarTimeAtLongitude(date, 0, longitude)
+  }
+
+  // Mean-solar-time reference (DST-free; 15°/h, east positive). Returns "hour:00 mean-solar-time
+  // of the local solar day that `date` falls on", mirroring noonAtTimeZone's semantics so the
+  // day-selection logic in readSunTimes keeps working. Only the solar day matters, so no rounding.
+  private static solarTimeAtLongitude (date: Date, hour: number, longitude: number): Date {
+    const offsetMs = (longitude / 15) * 3600000
+    const local = new Date(date.getTime() + offsetMs)
+    return new Date(Date.UTC(local.getUTCFullYear(), local.getUTCMonth(), local.getUTCDate(), hour) - offsetMs)
+  }
+
   private static getTimeInTimeZone (date: Date, time: string, timeZone: string) {
     const formatter = new Intl.DateTimeFormat('fr-CA',
       { timeZone: timeZone, timeZoneName: 'longOffset' })

--- a/tests/unit/components/horizonCard/HorizonCard.spec.ts
+++ b/tests/unit/components/horizonCard/HorizonCard.spec.ts
@@ -5,6 +5,7 @@ import { css, CSSResult } from 'lit'
 import { HorizonCard } from '../../../../src/components/horizonCard'
 import { Constants } from '../../../../src/constants'
 import type { EHorizonCardErrors, IHorizonCardConfig, THorizonCardData, TMoonData, TSunTimes } from '../../../../src/types'
+import { HelperFunctions } from '../../../../src/utils/HelperFunctions'
 import { I18N } from '../../../../src/utils/I18N'
 import { SaneHomeAssistant, TemplateResultTestHelper } from '../../../helpers/TestHelpers'
 import { default as SunCalcMock } from '../../../mocks/SunCalc'
@@ -1006,6 +1007,126 @@ describe('HorizonCard', () => {
         sunrise: new Date('2023-04-05T06:30:00Z'),
         sunset: new Date('2023-04-05T18:30:00Z')
       })
+    })
+  })
+
+  describe('longitude-derived computation reference', () => {
+    const now = new Date('2023-04-05T13:00:00Z')
+
+    describe('scoped (explicit longitude, no time_zone)', () => {
+      beforeEach(() => {
+        horizonCard.hass = SaneHomeAssistant
+        horizonCard.setConfig({ type: HorizonCard.cardType, latitude: 40, longitude: 175 } as IHorizonCardConfig)
+        jest.spyOn(horizonCard as any, 'now').mockReturnValue(now)
+      })
+
+      it('reads sun times from noonAtLongitude, not noonAtTimeZone', () => {
+        const noonAtLongitudeSpy = jest.spyOn(HelperFunctions, 'noonAtLongitude')
+        const noonAtTimeZoneSpy = jest.spyOn(HelperFunctions, 'noonAtTimeZone')
+
+        horizonCard['readSunTimes'](now, 40, 175, 0)
+
+        expect(noonAtLongitudeSpy).toHaveBeenCalled()
+        expect(noonAtTimeZoneSpy).not.toHaveBeenCalled()
+      })
+
+      it('reads moon times from midnightAtLongitude, not midnightAtTimeZone', () => {
+        const midnightAtLongitudeSpy = jest.spyOn(HelperFunctions, 'midnightAtLongitude')
+        const midnightAtTimeZoneSpy = jest.spyOn(HelperFunctions, 'midnightAtTimeZone')
+
+        horizonCard['computeMoonData'](now, 40, 175)
+
+        expect(midnightAtLongitudeSpy).toHaveBeenCalled()
+        expect(midnightAtTimeZoneSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('non-scoped (unchanged behaviour)', () => {
+      it('uses noonAtTimeZone for the HA default location (no config longitude)', () => {
+        horizonCard.hass = SaneHomeAssistant
+        horizonCard.setConfig({} as IHorizonCardConfig)
+        jest.spyOn(horizonCard as any, 'now').mockReturnValue(now)
+
+        const noonAtLongitudeSpy = jest.spyOn(HelperFunctions, 'noonAtLongitude')
+        const noonAtTimeZoneSpy = jest.spyOn(HelperFunctions, 'noonAtTimeZone')
+
+        horizonCard['readSunTimes'](now, 0, 0, 0)
+
+        expect(noonAtTimeZoneSpy).toHaveBeenCalled()
+        expect(noonAtLongitudeSpy).not.toHaveBeenCalled()
+      })
+
+      it('uses noonAtTimeZone when both longitude and time_zone are set', () => {
+        horizonCard.hass = SaneHomeAssistant
+        horizonCard.setConfig({
+          type: HorizonCard.cardType, latitude: 40, longitude: 175, time_zone: 'UTC'
+        } as IHorizonCardConfig)
+        jest.spyOn(horizonCard as any, 'now').mockReturnValue(now)
+
+        const noonAtLongitudeSpy = jest.spyOn(HelperFunctions, 'noonAtLongitude')
+        const noonAtTimeZoneSpy = jest.spyOn(HelperFunctions, 'noonAtTimeZone')
+
+        horizonCard['readSunTimes'](now, 40, 175, 0)
+
+        expect(noonAtTimeZoneSpy).toHaveBeenCalled()
+        expect(noonAtLongitudeSpy).not.toHaveBeenCalled()
+      })
+
+      it('uses midnightAtTimeZone for the moon when both longitude and time_zone are set', () => {
+        horizonCard.hass = SaneHomeAssistant
+        horizonCard.setConfig({
+          type: HorizonCard.cardType, latitude: 40, longitude: 175, time_zone: 'UTC'
+        } as IHorizonCardConfig)
+        jest.spyOn(horizonCard as any, 'now').mockReturnValue(now)
+
+        const midnightAtLongitudeSpy = jest.spyOn(HelperFunctions, 'midnightAtLongitude')
+        const midnightAtTimeZoneSpy = jest.spyOn(HelperFunctions, 'midnightAtTimeZone')
+
+        horizonCard['computeMoonData'](now, 40, 175)
+
+        expect(midnightAtTimeZoneSpy).toHaveBeenCalled()
+        expect(midnightAtLongitudeSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    it('selects a different solar day than the time zone path for a far-mismatched longitude', () => {
+      // End-to-end discrimination with the real (patched) suncalc, no helper spy. A far-east
+      // longitude paired with a UTC time zone puts `now` (~solar midnight) on the opposite side
+      // of the solar-day boundary, so the longitude path and the time-zone path return sun times
+      // for different solar days. A mild longitude would show no difference.
+      const actual = jest.requireActual('suncalc3')
+      const realSunCalc = actual.default ?? actual
+      jest.spyOn(SunCalcMock, 'getSunTimes')
+        .mockImplementation((...args: unknown[]) => realSunCalc.getSunTimes(...args))
+
+      const solarMidnight = new Date('2023-04-05T13:00:00Z')
+      const hass = {
+        ...SaneHomeAssistant,
+        config: { ...SaneHomeAssistant.config, time_zone: 'UTC' }
+      } as any
+
+      // Longitude path: explicit longitude, no time_zone.
+      horizonCard.hass = hass
+      horizonCard.setConfig({ type: HorizonCard.cardType, latitude: 40, longitude: 175 } as IHorizonCardConfig)
+      jest.spyOn(horizonCard as any, 'now').mockReturnValue(solarMidnight)
+      const longitudePath = horizonCard['readSunTimes'](solarMidnight, 40, 175, 0)
+
+      // Time-zone path: same location, but an explicit UTC time_zone.
+      const tzCard = new HorizonCard()
+      tzCard.attachShadow({ mode: 'open' })
+      tzCard.hass = hass
+      tzCard.setConfig({
+        type: HorizonCard.cardType, latitude: 40, longitude: 175, time_zone: 'UTC'
+      } as IHorizonCardConfig)
+      jest.spyOn(tzCard as any, 'now').mockReturnValue(solarMidnight)
+      const tzPath = tzCard['readSunTimes'](solarMidnight, 40, 175, 0)
+
+      expect(longitudePath.sunrise).toBeDefined()
+      expect(longitudePath.sunset).toBeDefined()
+      expect(tzPath.sunrise).toBeDefined()
+      expect(tzPath.sunset).toBeDefined()
+      expect(longitudePath.sunrise!.getTime()).not.toEqual(tzPath.sunrise!.getTime())
+      expect(longitudePath.sunset!.getTime()).not.toEqual(tzPath.sunset!.getTime())
     })
   })
 

--- a/tests/unit/utils/HelperFunctions.spec.ts
+++ b/tests/unit/utils/HelperFunctions.spec.ts
@@ -209,4 +209,60 @@ describe('HelperFunctions', () => {
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('noonAtLongitude', () => {
+    // Mean-solar-time reference: 15°/h, east positive, DST-free. Reference chosen at UTC noon so
+    // the solar day for 0/±90 does not shift, while ±180 lands on the adjacent solar day.
+    const date = new Date('2023-04-14T12:00:00.000Z')
+
+    it('returns solar noon at the prime meridian equal to UTC noon', () => {
+      const result = HelperFunctions.noonAtLongitude(date, 0)
+      expect(result).toEqual(new Date('2023-04-14T12:00:00.000Z'))
+      expect(result).toEqual(HelperFunctions.noonAtTimeZone(date, 'UTC'))
+    })
+
+    it('returns solar noon shifted 6 hours earlier at 90° east', () => {
+      const result = HelperFunctions.noonAtLongitude(date, 90)
+      expect(result).toEqual(new Date('2023-04-14T06:00:00.000Z'))
+    })
+
+    it('returns solar noon shifted 6 hours later at 90° west', () => {
+      const result = HelperFunctions.noonAtLongitude(date, -90)
+      expect(result).toEqual(new Date('2023-04-14T18:00:00.000Z'))
+    })
+
+    it('returns solar noon on the adjacent solar day at the antimeridian', () => {
+      const east = HelperFunctions.noonAtLongitude(date, 180)
+      const west = HelperFunctions.noonAtLongitude(date, -180)
+      expect(east).toEqual(new Date('2023-04-15T00:00:00.000Z'))
+      expect(west).toEqual(new Date('2023-04-15T00:00:00.000Z'))
+    })
+  })
+
+  describe('midnightAtLongitude', () => {
+    const date = new Date('2023-04-14T12:00:00.000Z')
+
+    it('returns solar midnight at the prime meridian equal to UTC midnight', () => {
+      const result = HelperFunctions.midnightAtLongitude(date, 0)
+      expect(result).toEqual(new Date('2023-04-14T00:00:00.000Z'))
+      expect(result).toEqual(HelperFunctions.midnightAtTimeZone(date, 'UTC'))
+    })
+
+    it('returns solar midnight shifted 6 hours earlier at 90° east', () => {
+      const result = HelperFunctions.midnightAtLongitude(date, 90)
+      expect(result).toEqual(new Date('2023-04-13T18:00:00.000Z'))
+    })
+
+    it('returns solar midnight shifted 6 hours later at 90° west', () => {
+      const result = HelperFunctions.midnightAtLongitude(date, -90)
+      expect(result).toEqual(new Date('2023-04-14T06:00:00.000Z'))
+    })
+
+    it('returns solar midnight on the adjacent solar day at the antimeridian', () => {
+      const east = HelperFunctions.midnightAtLongitude(date, 180)
+      const west = HelperFunctions.midnightAtLongitude(date, -180)
+      expect(east).toEqual(new Date('2023-04-14T12:00:00.000Z'))
+      expect(west).toEqual(new Date('2023-04-14T12:00:00.000Z'))
+    })
+  })
 })


### PR DESCRIPTION
## Overview

Resolves #71.

SunCalc picks the *solar day* from the reference instant the card passes it. Today that reference is always built from a political time zone (`config.time_zone ?? hass.config.time_zone`). When a user sets an explicit far-away `longitude` but a mismatched time zone, the reference can fall on the wrong side of the solar-day boundary, so SunCalc returns the **adjacent solar day's** sunrise/sunset/moon events — a whole-day selection error that looks like a few-minutes shift in HH:MM.

## Change

This adopts the two-axis model from @avataar's framing in #71: **`longitude` drives the computation, `time_zone` drives the display.**

- New `HelperFunctions.noonAtLongitude` / `midnightAtLongitude` compute a mean-solar-time reference (15°/h, east positive, DST-free), mirroring the existing `noonAtTimeZone` semantics.
- The sun/moon computation uses them **only** when the user set an explicit `longitude` without a `time_zone` (`useLongitudeForComputation()`), reading the **raw config** rather than the HA-fallback accessors — so every other setup (HA's own location, or any config with an explicit `time_zone`) stays byte-identical.

Scoped users still see times rendered in HA's political/browser zone; adding `time_zone:` restores foreign wall-clock display (that path is #188).

## Verification (in Docker)

`bash docker/run.sh` → lint 0 errors (2 pre-existing warnings), **729 tests** pass, build OK. New tests: exact-instant helper specs (incl. ±180° antimeridian), scoped/non-scoped selection specs, and a discriminating real-`suncalc3` end-to-end test (longitude 175 + `time_zone: UTC` + `now` near solar midnight → the longitude path selects a different solar day than the tz path, so the computed times observably differ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)