### PR TITLE
Fix gap below card in Sections view by content-sizing (#192)

### DIFF
--- a/src/components/horizonCard/HorizonCard.ts
+++ b/src/components/horizonCard/HorizonCard.ts
@@ -119,59 +119,17 @@ export class HorizonCard extends LitElement {
 	}
 
   /**
-   * Called by HASS to size the card in the Sections view grid. The grid has 12 columns;
-   * a cell is 56px tall with an 8px gap, so rows = ceil((pxHeight + 8) / 64).
+   * Called by HASS to size the card in the Sections view grid. We intentionally do NOT
+   * report a fixed `rows` value: the grid quantizes height to whole rows (56px cell + 8px
+   * gap), so any fixed count rounds up and leaves an empty gap below the card (issue #192).
+   * Omitting `rows` lets the card size to its actually-rendered content instead, so it is
+   * correct at whatever height the card renders — unlike the removed pixel model, which was
+   * calibrated for a single card width. We still declare the 12-column default and allow the
+   * card to be narrowed to half width.
    * @see https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card/#sizing-in-sections-view
    */
-  public getGridOptions (): { rows: number, columns: number, min_rows: number, min_columns: number } {
-    const rows = this.computeGridRows()
-    // The row model is calibrated at full (12-column) width. min_columns lets the card
-    // be narrowed to half width; at narrower widths reflowed content may need slightly
-    // more height than reported (a cosmetic clip, never on the default full-width layout).
-    return { rows, columns: 12, min_rows: rows, min_columns: 6 }
-  }
-
-  private computeGridRows (): number {
-    // Section pixel heights measured at ~480px card width (see PR #158).
-    const height = {
-      graph: 187.08,
-      title: 41,
-      sunrise_sunset: 42.17,
-      dawn_noon_dusk: 48.3,
-      single_azimuth_elevation: 48.3,
-      both_azimuth_elevation: 66.78,
-      // Bumped from PR #158's 48.3: the Playwright visual tests showed the busiest
-      // moon config renders one grid row taller than the raw model, so this keeps
-      // getGridOptions() from ever under-reporting rows (which would clip the card).
-      moon_row: 58
-    }
-
-    let size = height.graph
-    const fieldConfig = this.expandedFieldConfig()
-
-    if (this.config?.title && this.config.title.length > 0) {
-      size += height.title
-    }
-
-    if (fieldConfig.sunrise || fieldConfig.sunset) {
-      size += height.sunrise_sunset
-    }
-
-    if (fieldConfig.dawn || fieldConfig.noon || fieldConfig.dusk) {
-      size += height.dawn_noon_dusk
-    }
-
-    if ((fieldConfig.sun_azimuth && fieldConfig.moon_azimuth) || (fieldConfig.sun_elevation && fieldConfig.moon_elevation)) {
-      size += height.both_azimuth_elevation
-    } else if (fieldConfig.sun_azimuth || fieldConfig.moon_azimuth || fieldConfig.sun_elevation || fieldConfig.moon_elevation) {
-      size += height.single_azimuth_elevation
-    }
-
-    if (fieldConfig.moonrise || fieldConfig.moon_phase || fieldConfig.moonset) {
-      size += height.moon_row
-    }
-
-    return Math.ceil((size + 8) / 64)
+  public getGridOptions (): { columns: number, min_columns: number } {
+    return { columns: 12, min_columns: 6 }
   }
 
   // called by HASS whenever config changes

--- a/tests/unit/components/horizonCard/HorizonCard.spec.ts
+++ b/tests/unit/components/horizonCard/HorizonCard.spec.ts
@@ -785,125 +785,27 @@ describe('HorizonCard', () => {
   })
 
   describe('getGridOptions', () => {
-    // Note: don't set hass for these tests, getGridOptions() is called after setConfig() but before hass is set.
-    // The expected row count is derived from the same section pixel-height model used by the implementation so
-    // that these tests pin the behavior (12-column grid, 56px cell + 8px gap => rows = ceil((height + 8) / 64)).
-    const heightModel = {
-      graph: 187.08,
-      title: 41,
-      sunrise_sunset: 42.17,
-      dawn_noon_dusk: 48.3,
-      single_azimuth_elevation: 48.3,
-      both_azimuth_elevation: 66.78,
-      // Kept in sync with computeGridRows() in HorizonCard.ts (bumped to 58 per visual tests).
-      moon_row: 58
-    }
-
-    // resolved represents the per-field booleans as returned by expandedFieldConfig(), plus a title flag
-    const expectedRows = (resolved: Record<string, boolean>): number => {
-      let size = heightModel.graph
-      if (resolved.title) {
-        size += heightModel.title
-      }
-      if (resolved.sunrise || resolved.sunset) {
-        size += heightModel.sunrise_sunset
-      }
-      if (resolved.dawn || resolved.noon || resolved.dusk) {
-        size += heightModel.dawn_noon_dusk
-      }
-      if ((resolved.sun_azimuth && resolved.moon_azimuth) || (resolved.sun_elevation && resolved.moon_elevation)) {
-        size += heightModel.both_azimuth_elevation
-      } else if (resolved.sun_azimuth || resolved.moon_azimuth || resolved.sun_elevation || resolved.moon_elevation) {
-        size += heightModel.single_azimuth_elevation
-      }
-      if (resolved.moonrise || resolved.moon_phase || resolved.moonset) {
-        size += heightModel.moon_row
-      }
-      return Math.ceil((size + 8) / 64)
-    }
-
-    const cases: { name: string, config: IHorizonCardConfig, resolved: Record<string, boolean> }[] = [
-      {
-        name: 'graph-only (all default fields disabled)',
-        config: {
-          fields: { sunrise: false, sunset: false, dawn: false, noon: false, dusk: false }
-        } as IHorizonCardConfig,
-        resolved: {}
-      },
-      {
-        name: 'default fields',
-        config: {} as IHorizonCardConfig,
-        resolved: { sunrise: true, sunset: true, dawn: true, noon: true, dusk: true }
-      },
-      {
-        name: 'default fields with a title',
-        config: { title: 'Fancy Card' } as IHorizonCardConfig,
-        resolved: { title: true, sunrise: true, sunset: true, dawn: true, noon: true, dusk: true }
-      },
-      {
-        name: 'sunrise/sunset only',
-        config: {
-          fields: { dawn: false, noon: false, dusk: false }
-        } as IHorizonCardConfig,
-        resolved: { sunrise: true, sunset: true }
-      },
-      {
-        name: 'all fields including moon and a title',
-        config: {
-          title: 'Fancy Card',
-          fields: { azimuth: true, elevation: true, moonrise: true, moonset: true, moon_phase: true }
-        } as IHorizonCardConfig,
-        resolved: {
-          title: true, sunrise: true, sunset: true, dawn: true, noon: true, dusk: true,
-          sun_azimuth: true, moon_azimuth: true, sun_elevation: true, moon_elevation: true,
-          moonrise: true, moon_phase: true, moonset: true
-        }
-      },
-      {
-        name: 'moon fields only',
-        config: {
-          fields: { sunrise: false, sunset: false, dawn: false, noon: false, dusk: false,
-            moonrise: true, moonset: true, moon_phase: true }
-        } as IHorizonCardConfig,
-        resolved: { moonrise: true, moon_phase: true, moonset: true }
-      },
-      {
-        name: 'single elevation only (exercises the shorter azimuth/elevation row)',
-        config: {
-          fields: { sunrise: false, sunset: false, dawn: false, noon: false, dusk: false, sun_elevation: true }
-        } as IHorizonCardConfig,
-        resolved: { sun_elevation: true }
-      },
-      {
-        name: 'single azimuth only (exercises the shorter azimuth/elevation row)',
-        config: {
-          fields: { sunrise: false, sunset: false, dawn: false, noon: false, dusk: false, sun_azimuth: true }
-        } as IHorizonCardConfig,
-        resolved: { sun_azimuth: true }
-      }
-    ]
-
-    for (const { name, config, resolved } of cases) {
-      it(`returns the expected grid options for ${name}`, () => {
-        horizonCard.setConfig(config)
-
-        const rows = expectedRows(resolved)
-        expect(horizonCard.getGridOptions()).toEqual({
-          rows,
-          columns: 12,
-          min_rows: rows,
-          min_columns: 6
-        })
-      })
-    }
-
-    it('always reports a 12-column grid with a 6-column minimum and min_rows equal to rows', () => {
+    // The card must size to its rendered content in the Sections view. Reporting a fixed
+    // `rows` count quantizes the card to whole grid rows and leaves an empty gap below it
+    // (issue #192), so getGridOptions() intentionally omits `rows`/`min_rows` and only pins
+    // the columns (12 by default, narrowable to half width via min_columns).
+    it('reports a 12-column default that can be narrowed to half width', () => {
       horizonCard.setConfig({} as IHorizonCardConfig)
 
-      const gridOptions = horizonCard.getGridOptions()
-      expect(gridOptions.columns).toEqual(12)
-      expect(gridOptions.min_columns).toEqual(6)
-      expect(gridOptions.min_rows).toEqual(gridOptions.rows)
+      expect(horizonCard.getGridOptions()).toEqual({ columns: 12, min_columns: 6 })
+    })
+
+    it('stays config-independent: even the heaviest config never pins a row count', () => {
+      // Regression guard against re-introducing a config-dependent `rows`: this config used
+      // to produce the tallest fixed row estimate, and it must now still omit rows/min_rows.
+      horizonCard.setConfig({
+        title: 'Fancy Card',
+        fields: { azimuth: true, elevation: true, moonrise: true, moonset: true, moon_phase: true }
+      } as IHorizonCardConfig)
+
+      const gridOptions = horizonCard.getGridOptions() as Record<string, unknown>
+      expect(gridOptions.rows).toBeUndefined()
+      expect(gridOptions.min_rows).toBeUndefined()
     })
   })
 

--- a/tests/visual/grid-sizing.spec.ts
+++ b/tests/visual/grid-sizing.spec.ts
@@ -4,21 +4,17 @@ declare global {
   interface Window {
     setContainerWidth: (width: number) => void
     renderCard: (config: Record<string, unknown>) => Promise<unknown>
-    getGridOptions: () => { rows: number, columns: number, min_rows: number, min_columns: number }
     measureCardHeight: () => number
   }
 }
 
-// The card is measured at a full-width (12 column) Sections-view card.
+// The card is rendered as a full-width (12 column) Sections-view card.
 const CONTAINER_WIDTH = 492
 
-// Grid geometry used by getGridOptions(): a 12-column grid where each cell is
-// 56px tall with an 8px gap, so rows = ceil((pxHeight + 8) / 64).
-const rowsForHeight = (heightPx: number): number => Math.ceil((heightPx + 8) / 64)
-
-// Invariant: getGridOptions() must never UNDER-report rows, or the card would be
-// clipped in the Sections grid. Over-reporting (a little extra whitespace) is
-// acceptable, so we assert modelRows >= the rows the card actually renders into.
+// getGridOptions() intentionally omits `rows` so the card sizes to its rendered
+// content (issue #192) rather than being quantized to whole grid rows. These tests
+// therefore render each configuration at a stable width and pin the drawing with a
+// screenshot; the moon cases additionally guard the disc geometry for #82 and #142.
 
 const cases: { name: string, config: Record<string, unknown> }[] = [
   {
@@ -72,24 +68,19 @@ const cases: { name: string, config: Record<string, unknown> }[] = [
   }
 ]
 
-test.describe('getGridOptions height model', () => {
+test.describe('Sections view rendering', () => {
   for (const { name, config } of cases) {
-    test(`rendered card height matches getGridOptions() rows for ${name}`, async ({ page }, testInfo) => {
+    test(`renders ${name}`, async ({ page }, testInfo) => {
       await page.goto('/tests/visual/harness.html')
       await page.evaluate((width) => window.setContainerWidth(width), CONTAINER_WIDTH)
       await page.evaluate((cardConfig) => window.renderCard(cardConfig), config)
 
+      // Record the rendered height so unexpected size changes surface in the report.
       const measuredHeight = await page.evaluate(() => window.measureCardHeight())
-      const modelRows = await page.evaluate(() => window.getGridOptions().rows)
-      const measuredRows = rowsForHeight(measuredHeight)
-
-      // Record the numbers so divergence between the model and reality is visible.
       testInfo.annotations.push({
         type: 'measurement',
-        description: `height=${measuredHeight.toFixed(2)}px measuredRows=${measuredRows} modelRows=${modelRows}`
+        description: `height=${measuredHeight.toFixed(2)}px`
       })
-
-      expect(modelRows).toBeGreaterThanOrEqual(measuredRows)
 
       await expect(page.locator('#container')).toHaveScreenshot(`${name}.png`)
     })

--- a/tests/visual/harness.html
+++ b/tests/visual/harness.html
@@ -128,9 +128,6 @@
       return fullConfig
     }
 
-    // Expose getGridOptions() as computed by the card itself.
-    window.getGridOptions = () => document.getElementById('card').getGridOptions()
-
     // Measure the actual rendered height of the card element.
     window.measureCardHeight = () => document.getElementById('card').getBoundingClientRect().height
   </script>


### PR DESCRIPTION
## Overview

Fixes #192 — an unexpected vertical gap directly below the card in Home Assistant's **Sections** view (v1.4.3, absent in v1.4.0).

**Root cause:** `getGridOptions()` (added in #186) reported a *fixed* row count from a per-section pixel model. HA's Sections grid quantizes height to whole rows (56px cell + 8px gap = 64px steps), and the estimate was `ceil`-rounded *and* deliberately over-reported, so the allocated cell was always taller than the content → the gap.

**Fix:** omit `rows` and return only `{ columns: 12, min_columns: 6 }`, so the card sizes to its actually-rendered content — HA's documented "ignore the rows of the grid" path. This restores the gapless v1.4.0 behavior while keeping the 12-column / half-width grid participation from #145. The now-dead pixel model and its tests are removed.

> Note on lineage: this deliberately **rolls back the fixed row-count mechanism** that shipped in #186 (the never-merged idea originated in #158). It does **not** undo grid-system compatibility — the card still participates in the grid via columns; only the invented height is gone.

## Reference

Home Assistant developer docs — [Custom card: Sizing in section view / `getGridOptions()`](https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card/):

- On the `rows` field: *"Do not define this value if you want your card to ignore the rows of the grid (not defined by default)"*
- On the default when `getGridOptions()` is absent: *"If you don't define this method, the card will take 12 columns and will ignore the rows of the grid."* — i.e. exactly the gapless v1.4.0 behavior this fix returns to at the row level.

## Verification (Docker only, per this repo's setup)

- `docker/run.sh` → lint ✅ (0 errors), test ✅ **725 passed / 63 snapshots**, build ✅
- `docker/run-visual.sh` → ✅ **7/7** (incl. the #82/#142 moon guards; baselines unchanged — `getGridOptions` is grid metadata and never touches the DOM)

Independently reviewed (code review + adversarial critic): both accept; no blocking findings.

## Type of Change

- [x] Bugfix

## Related

Fixes #192 · rolls back the row model from #186 · goal of #145 preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)