### PR TITLE
Fix Jest 30 CI failure: update snapshot guide-link headers

### DIFF
--- a/tests/unit/components/__snapshots__/HorizonErrorContent.spec.ts.snap
+++ b/tests/unit/components/__snapshots__/HorizonErrorContent.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HorizonErrorContent render returns a valid error template result 1`] = `
 <div class="horizon-card-error">

--- a/tests/unit/components/horizonCard/__snapshots__/HorizonCard.spec.ts.snap
+++ b/tests/unit/components/horizonCard/__snapshots__/HorizonCard.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HorizonCard render renders an error if error is present on data 1`] = `
 <div class="horizon-card-error">

--- a/tests/unit/components/horizonCard/__snapshots__/HorizonCardContent.spec.ts.snap
+++ b/tests/unit/components/horizonCard/__snapshots__/HorizonCardContent.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HorizonCardContent render renders the card content 1`] = `
 <ha-card>

--- a/tests/unit/components/horizonCard/__snapshots__/HorizonCardFooter.spec.ts.snap
+++ b/tests/unit/components/horizonCard/__snapshots__/HorizonCardFooter.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HorizonCardFooter render should not render the dawn field when it is not present in the config but data for it is provided 1`] = `
 <div class="horizon-card-footer">

--- a/tests/unit/components/horizonCard/__snapshots__/HorizonCardGraph.spec.ts.snap
+++ b/tests/unit/components/horizonCard/__snapshots__/HorizonCardGraph.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HorizonCardGraph render does not render the moon when not configured so 1`] = `
 <div class="horizon-card-graph">

--- a/tests/unit/components/horizonCard/__snapshots__/HorizonCardHeader.spec.ts.snap
+++ b/tests/unit/components/horizonCard/__snapshots__/HorizonCardHeader.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HorizonCardHeader render does not render the sunrise field when it is not present in the data and it is disabled on the config 1`] = `
 <div class="horizon-card-header">

--- a/tests/unit/utils/__snapshots__/HelperFunctions.spec.ts.snap
+++ b/tests/unit/utils/__snapshots__/HelperFunctions.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HelperFunctions renderFieldElement returns a field element template when Moon integration is missing 1`] = `
 <div class="horizon-card-text-container">


### PR DESCRIPTION
## Problem

Since the Jest 30 upgrade (#200), **every** PR's `PR Build & Test` fails (surfaced by #201, an ImgBot PNG-optimization PR that only touches image files):

```
Test suite failed to run
  Outdated guide link: The snapshot guide link at the top of this snapshot is
  outdated. Please update all snapshots during this upgrade of Jest.
  at validateSnapshotHeader (@jest/snapshot-utils)
```

Jest 30 validates the guide-link header in `.snap` files. All 7 snapshots carry the old `https://goo.gl/fbAQLP` link, which Jest 30 rejects **in CI mode** (`CI=true`).

**Why local verification missed it:** without `CI=true`, jest silently auto-updates the header, so `docker/run.sh yarn test` passed locally. GitHub Actions (and the release workflow) set `CI=true`, so they fail — this would also have broken the release build.

## Fix

Update all 7 snapshot headers to the current link (`https://jestjs.io/docs/snapshot-testing`) — exactly what `jest -u` writes. Snapshot **content is unchanged**.

## Verification (Docker, now with `CI=true` to match GitHub Actions)
- `docker/run.sh sh -lc "CI=true yarn lint && CI=true yarn test && CI=true yarn build"` → lint clean, **740 tests pass**, build ✅

## Type of Change
- [x] Bugfix (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)