### PR TITLE
Give the card its own Moon phase names (moon-phase text cluster)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ _Example: [here](#example-config)_
 
 ### Caveats
 
-The Moon phase name (if the field `moon_phase` is enabled) is obtained via the [Moon integration](https://www.home-assistant.io/integrations/moon/). If the integration is not installed, the card will still show the Moon phase as a human-readable constant followed by `(!)`, e.g., `waning_gibbuous (!)`. Due to the way Home Assistant works, the localized Moon phase name will always be in Home Assistant's language and not in the language set for the card via the `language` option.
+The Moon phase name (if the field `moon_phase` is enabled) is obtained via the [Moon integration](https://www.home-assistant.io/integrations/moon/), localized in Home Assistant's language. If the integration is not installed, the card falls back to its own phase name (e.g. `Full moon`), shown in the card's `language` when that translation exists and in English otherwise. Note that when the Moon integration _is_ installed, its name always follows Home Assistant's language rather than the card's `language` option.
 
 ### Example config
 

--- a/src/assets/localization/languages/en.json
+++ b/src/assets/localization/languages/en.json
@@ -8,5 +8,13 @@
   "moonset": "Moonset",
   "noon": "Solar noon",
   "sunrise": "Sunrise",
-  "sunset": "Sunset"
+  "sunset": "Sunset",
+  "new_moon": "New moon",
+  "waxing_crescent": "Waxing crescent",
+  "first_quarter": "First quarter",
+  "waxing_gibbous": "Waxing gibbous",
+  "full_moon": "Full moon",
+  "waning_gibbous": "Waning gibbous",
+  "last_quarter": "Last quarter",
+  "waning_crescent": "Waning crescent"
 }

--- a/src/utils/HelperFunctions.ts
+++ b/src/utils/HelperFunctions.ts
@@ -31,9 +31,13 @@ export class HelperFunctions {
       return nothing
     }
 
+    // Prefer Home Assistant's Moon integration string (localized in HA's language). When it
+    // is absent (integration not installed, or no HA-side localization for the key), fall back
+    // to the card's own phase name — keyed by the HA state string — which is localized in the
+    // card's language when available and English otherwise, instead of a raw `state (!)`.
     let moon_phase_localized: unknown = i18n.localize(`component.moon.entity.sensor.phase.state.${phase.state}`)
     if (!moon_phase_localized) {
-      moon_phase_localized = html`<span title="Install Moon integration to get localized Moon phase name">${phase.state} (!)</span>`
+      moon_phase_localized = i18n.tr(phase.state)
     }
 
     return html`

--- a/tests/unit/utils/__snapshots__/HelperFunctions.spec.ts.snap
+++ b/tests/unit/utils/__snapshots__/HelperFunctions.spec.ts.snap
@@ -9,9 +9,7 @@ exports[`HelperFunctions renderFieldElement returns a field element template whe
     </ha-icon>
   </div>
   <div class="horizon-card-field-value horizon-card-field-value-moon-phase">
-    <span title="Install Moon integration to get localized Moon phase name">
-      full_moon (!)
-    </span>
+    Full moon
   </div>
 </div>
 `;


### PR DESCRIPTION
## Overview

Fixes the moon-phase-text cluster. Today the card sources the Moon phase **name** entirely from HA's Moon integration (`component.moon.entity.sensor.phase.state.*`); without that integration it renders an ugly placeholder like `full_moon (!)`.

This gives the card its **own** phase names as a graceful fallback:
- HA's localized name stays **primary** — users with the Moon integration are byte-for-byte unaffected.
- When it's absent, fall back to `i18n.tr(phase.state)` — the card's own name, in the card's `language` when a translation exists, else English — instead of `state (!)`.

## Issues

- **Fixes #167** — no more `full_moon (!)`; users without the integration now see a real name (e.g. `Full moon`).
- **Addresses #150 / #171 / #174** — the root cause (card had no own phase strings) is fixed; these users now get a readable English name immediately, and their language becomes a **trivial** additive follow-up via the localization JSON (the codegen makes it a one-file change). *Not auto-closed — leaving open until each language's strings land, if you'd like.*
- Out of scope: #178 (phase icon/rotation) is deliberately untouched.

## Changes
- `en.json`: 8 phase keys matching HA's English sentence case, keyed exactly by the `MOON_PHASES` state strings (incl. the `last_quarter` ≠ `third_quarter` trap).
- `HelperFunctions.ts` `renderMoonElement`: fallback → `i18n.tr(phase.state)`; drop the `(!)` span/tooltip.
- `README.md`: update the Caveats paragraph (+ fix a pre-existing "gibbuous" typo).
- One unit snapshot regenerated (`full_moon (!)` → `Full moon`).

## Process (agent-based, loop-verified)
- Design validated by **architect + critic** (Option B: HA-localize primary, card-`tr` fallback — non-regressive).
- Implementation independently **code-reviewed → APPROVE**, 0 blocking issues.

## Verification (Docker only, with `CI=true`)
- `docker/run.sh` → lint ✅ (0 errors), test ✅ **740 passed**, build ✅
- `docker/run-visual.sh` → ✅ **7/7 unchanged** (visual harness's localize is truthy → primary path, so screenshots are untouched)

## Type of Change
- [x] Bugfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)