### PR TITLE
Remove non-functional no_card; document standard transparent/embed recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ In general, you should not need to set any of these as they override Home Assist
 | longitude     | _number_                                     | Longitude used for calculations                                                                                               | Home Assistant longitude                                    |
 | elevation     | _number_                                     | Elevation (above sea) used for calculations                                                                                   | Home Assistant elevation                                    |
 | time_zone     | _string_                                     | Time zone (IANA) used for calculations and time presentation                                                                  | Home Assistant time zone                                    |
-| no_card       | _boolean_                                    | Disable card background                                                                                                       | `false`                                                     |
 | now           | _Date_                                       | Overrides the current moment shown on the card                                                                                | Current time                                                |
 | debug_level   | _number_                                     | Sets debug level, `0` (no debug), `1` and `2`                                                                                 | `0`                                                         |
 
@@ -234,11 +233,51 @@ latitude: 42.55
 longitude: 23.25
 elevation: 1500
 time_zone: Europe/Sofia
-no_card: false
 now: 2023-07-06T00:30:05+0300
 debug_level: 0
 ```
 
+### Card background and embedding
+
+The card renders inside Home Assistant's standard `ha-card`, so its background, border and shadow follow your theme. There is no card-specific option to switch them off — use Home Assistant's normal styling mechanisms instead, e.g. a theme or [card-mod](https://github.com/thomasloven/lovelace-card-mod).
+
+**Make the card transparent** (remove its background, border and shadow), for example to blend it into a dashboard:
+
+```yaml
+type: custom:horizon-card
+card_mod:
+  style: |
+    ha-card {
+      --ha-card-background: none;
+      --ha-card-box-shadow: none;
+      --ha-card-border-width: 0;
+    }
+```
+
+**Graph only, edge to edge** — additionally collapse the card's inner padding and margins so the graph fills the width with no whitespace below (handy inside a `vertical-stack`):
+
+```yaml
+type: custom:horizon-card
+moon: true
+fields:
+  sunrise: false
+  sunset: false
+  dawn: false
+  noon: false
+  dusk: false
+card_mod:
+  style: |
+    ha-card {
+      --ha-card-background: none;
+      --ha-card-box-shadow: none;
+      --ha-card-border-width: 0;
+    }
+    .horizon-card { padding: 0; }
+    .horizon-card-graph { margin: 0; }
+    .horizon-card-footer { margin-bottom: 0; }
+```
+
+The `--ha-card-*` custom properties are Home Assistant's standard card variables (a theme can set them too); the `.horizon-card*` selectors target the card's internal layout.
 
 ## Development
 


### PR DESCRIPTION
## Summary

`no_card` was a documented-but-unimplemented option: it only ever existed as a README entry (added doc-only in #140, 2024) and was never wired into the code or config type, so `no_card: true` silently did nothing — the root of #204.

Rather than implement a bespoke option, this **removes `no_card`** and **documents Home Assistant's standard styling approach**, which is more idiomatic and also solves the reporter's actual goal (a graph-only, whitespace-free embed).

## Changes
- **Remove `no_card`** from the advanced-options table and the example config (README-only; it was never in the code).
- **Add a "Card background and embedding" section** with two recipes:
  - *Transparent card* — set `--ha-card-background` / `--ha-card-box-shadow` / `--ha-card-border-width` to none/0 (via theme or card-mod).
  - *Graph only, edge to edge* — additionally collapse `.horizon-card` padding and the graph/footer margins so the graph fills the width with no whitespace below.

## Why this instead of a bespoke option
Ecosystem research: no well-known card uses `no_card`, and none omit `<ha-card>` from the DOM — the idiomatic pattern is manipulating `ha-card` via its `--ha-card-*` custom properties (exactly what card-mod and `stack-in-card` do). The fork parent (`AitorDB/home-assistant-sun-card`) never had `no_card` either, so there was no original behavior to restore. The CSS-variable / card-mod route is the correct HA answer.

## Verification (screenshot)
Rendered the #204 graph-only config and captured three states — baseline (full chrome) → chrome removed (`--ha-card-*`) → full recipe (chrome + spacing). The chrome is faithfully removed and the graph fills edge-to-edge with the whitespace collapsed; card height drops **165px → 108px**. (Verified through the Playwright visual harness using an `ha-card` stub that honors the real `--ha-card-*` variables.)

Docs-only change — suggest merging with `norelease` (no version bump needed).

Closes #204.
