### PR TITLE
CI: upload the built card as a downloadable PR artifact

### DIFF
--- a/.github/workflows/pr-build-and-test.yaml
+++ b/.github/workflows/pr-build-and-test.yaml
@@ -34,3 +34,10 @@ jobs:
 
       - name: Build
         run: yarn build
+
+      - name: Upload built card
+        uses: actions/upload-artifact@v4
+        with:
+          name: lovelace-horizon-card
+          path: dist/lovelace-horizon-card.js
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Build the card on every pull request (and every push to a PR branch) and upload the built `dist/lovelace-horizon-card.js` as a workflow artifact, so anyone can download it and load it in Home Assistant to test the PR before it is merged. A plain CI/CD per-PR build.

## How to use

On any PR, open the **PR Build & Test** check → **Summary** → **Artifacts** → download `lovelace-horizon-card`. Unzip and drop `lovelace-horizon-card.js` into your HA `config/www/`, add it as a Lovelace resource (JavaScript Module, e.g. `/local/lovelace-horizon-card.js`), and hard-refresh. Use a cache-busting `?v=<sha>` if it replaces an existing resource.

## Change

One `actions/upload-artifact@v4` step appended to the existing `Pull Request Build & Test` workflow, right after the Build step. No extra build, it reuses the one that already runs. The `pull_request` trigger already fires on every push to a PR branch, so each push refreshes the artifact.
