### PR TITLE
Add manual HACS pre-release (beta) workflow

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,73 @@
+name: Build & Pre-release (beta)
+
+# Publish a HACS beta. HACS only offers pre-releases to users who have enabled
+# "Show beta versions" for the repository, so a beta does not notify everyone
+# the way a normal release does (see #215). Run this manually from the branch
+# you want to ship and give it a semver pre-release tag such as v2.0.0-beta.1.
+#
+# This is intentionally decoupled from the stable release flow (release.yaml):
+# it never runs on push, you choose the exact version yourself, and the release
+# is flagged as a pre-release. The stable auto-release reads GitHub's "latest
+# release" endpoint, which skips pre-releases, so betas never affect how the
+# next stable version number is computed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Pre-release tag (semver pre-release, e.g. v2.0.0-beta.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-prerelease:
+    name: Build & Pre-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate pre-release tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z][0-9A-Za-z.-]*$ ]]; then
+            echo "::error::'$VERSION' is not a semver pre-release tag."
+            echo "::error::Use a 'v' prefix, X.Y.Z and a '-<identifier>' suffix, e.g. v2.0.0-beta.1."
+            echo "::error::For a normal (stable) release, merge to main with a release:* label instead."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version-file: .nvmrc
+
+      - name: Install Dependencies
+        run: yarn install --immutable
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Test
+        run: yarn test
+
+      - name: Build
+        run: yarn build
+
+      - name: Create pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.version }}
+          target_commitish: ${{ github.sha }}
+          name: ${{ inputs.version }}
+          prerelease: true
+          generate_release_notes: true
+          files: dist/lovelace-horizon-card.js


### PR DESCRIPTION
## What

Adds `.github/workflows/prerelease.yaml`: a manual **workflow_dispatch** job to publish a HACS beta such as `v2.0.0-beta.1`.

It builds the selected branch and creates a GitHub release flagged `prerelease: true`, with auto-generated notes and the `dist/lovelace-horizon-card.js` asset attached (the filename HACS reads from `hacs.json`).

## Why

Several users in #215 reported that frequent releases spam the HA update notification. HACS only offers a **pre-release** to users who have opted in via the repository's **"Show beta versions"** toggle. So betas let us ship work for testers without notifying everyone, while the stable line stays quiet until a real release.

## How to use

1. Actions tab → **Build & Pre-release (beta)** → **Run workflow**.
2. Pick the branch you want to ship from.
3. Enter the tag, e.g. `v2.0.0-beta.1` (must be a semver pre-release, i.e. contain a `-<identifier>` suffix; the job rejects anything else and points you at the stable flow).

When the work is ready for everyone, cut the stable release the normal way (merge to `main` with a `release:major` label).

## Decoupled from the stable flow

- Never runs on push; it is manual only.
- The version is entered by hand, so the `release:*` label bump logic is not involved.
- The release is flagged `prerelease: true`. `release.yaml` computes the next stable version from GitHub's **"latest release"** endpoint, which excludes pre-releases and drafts, so betas never shift how the next stable number (e.g. `2.0.0`) is chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)