### PR TITLE
Make the graph colours themeable and default the arrow to the horizon line

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ uix:
 
 Set `graph: false` for a values-only card, or `fields: false` for a graph-only one.
 
-For finer control (an edge-to-edge graph, recolouring individual elements or styling a single field), every drawn element has a stable CSS class and every colour is an `--hc-*` variable. The colours can be set straight in a Home Assistant theme, which is the fastest option since the card picks them up as it loads, or targeted with Uix or card-mod. The names are in the card's source, and [`tests/manual/styling-and-embedding.yaml`](tests/manual/styling-and-embedding.yaml) has a worked example for each case.
+For finer control (an edge-to-edge graph, recolouring individual elements or styling a single field), every drawn element has a stable CSS class and every colour is an `--hc-*` variable. The colours can be set straight in a Home Assistant theme, which is the fastest option since they apply through the normal CSS cascade, or targeted with Uix or card-mod. The names are in the card's source, and [`tests/manual/styling-and-embedding.yaml`](tests/manual/styling-and-embedding.yaml) has a worked example for each case.
 
 **Theming**
 
@@ -281,7 +281,7 @@ frontend:
       hc-moon-color: "#cfd8dc"
 ```
 
-Select the theme as usual (in your user profile, or per dashboard). The card reads the colours as it loads, so this is the quickest way to recolour it and needs no extra styling integration.
+Select the theme as usual (in your user profile, or per dashboard). The colours are ordinary CSS variables resolved through the normal cascade, so a theme, a card-mod/Uix override on `ha-card`, or a per-element override all take effect (and update live) with no extra styling integration.
 
 ## Development
 

--- a/src/cardStyles.ts
+++ b/src/cardStyles.ts
@@ -1,27 +1,18 @@
 import { css } from 'lit'
 
 export default css`
+  /* Theming note: the public --hc-*-color variables are intentionally NOT declared on :host.
+     A declaration on :host wins over a value inherited from an ancestor, which would mask a
+     Home Assistant theme (set on the document root) — only a card-mod/Uix override on ha-card,
+     a descendant, would then work. Instead each colour is consumed at its point of use as
+     var(--hc-…-color, <default>), so a theme (ancestor), card-mod (ha-card), an element-level
+     override AND the default all resolve. Only internal, non-themeable seeds live on :host:
+     the dark-mode-aware --hc-accent and the computed --_hc-* defaults. */
   :host {
     --hc-primary: var(--primary-text-color);
     --hc-secondary: var(--secondary-text-color);
 
-    --hc-field-name-color: var(--hc-secondary);
-    --hc-field-value-color: var(--hc-primary);
-    --hc-field-value-secondary-color: var(--hc-field-value-color);
-    --hc-moon-phase-icon-color: var(--primary-color);
-
-    --hc-daytime-past-color: #8ebeeb;
-    --hc-daytime-upcoming-color: transparent;
-    --hc-nighttime-past-color: #393b78;
-    --hc-nighttime-upcoming-color: transparent;
-
     --hc-accent: #d7d7d7;
-    --hc-lines: var(--hc-accent);
-    --hc-sunrise-line-color: var(--hc-lines);
-    --hc-sunset-line-color: var(--hc-lines);
-    --hc-sun-path-color: var(--hc-lines);
-    --hc-horizon-line-color: var(--hc-lines);
-    --hc-time-arrow-color: var(--hc-lines);
 
     --hc-sun-hue: 44;
     --hc-sun-saturation: 93%;
@@ -29,7 +20,7 @@ export default css`
     --hc-sun-hue-reduce: 0;
     --hc-sun-saturation-reduce: 0%;
     --hc-sun-lightness-reduce: 0%;
-    --hc-sun-color: hsl(
+    --_hc-sun-color: hsl(
       calc(var(--hc-sun-hue) - var(--hc-sun-hue-reduce)),
       calc(var(--hc-sun-saturation) - var(--hc-sun-saturation-reduce)),
       calc(var(--hc-sun-lightness) - var(--hc-sun-lightness-reduce))
@@ -40,20 +31,19 @@ export default css`
     --hc-moon-lightness: 82%;
     --hc-moon-saturation-reduce: 0%;
     --hc-moon-lightness-reduce: 0%;
-    --hc-moon-color: hsl(
+    --_hc-moon-color: hsl(
       var(--hc-moon-hue),
       calc(var(--hc-moon-saturation) - var(--hc-moon-saturation-reduce)),
       calc(var(--hc-moon-lightness) - var(--hc-moon-lightness-reduce))
     );
-    --hc-moon-shadow-color: #5f6b7a;
-    --hc-moon-outline-color: #5f6b7a;
-    --hc-moon-spot-color: rgba(170, 170, 170, 0.1);
+    --_hc-moon-shadow-color: #5f6b7a;
+    --_hc-moon-outline-color: #5f6b7a;
   }
 
   :host(.horizon-card-dark) {
     --hc-accent: #464646;
-    --hc-moon-shadow-color: #3b4653;
-    --hc-moon-outline-color: #6b7789;
+    --_hc-moon-shadow-color: #3b4653;
+    --_hc-moon-outline-color: #6b7789;
   }
 
   .horizon-card {
@@ -81,11 +71,11 @@ export default css`
   }
 
   .horizon-card-field-name {
-    color: var(--hc-field-name-color);
+    color: var(--hc-field-name-color, var(--hc-secondary));
   }
 
   .horizon-card-field-value {
-    color: var(--hc-field-value-color);
+    color: var(--hc-field-value-color, var(--hc-primary));
     font-size: 1.2em;
     line-height: 1.1em;
     text-align: center;
@@ -97,11 +87,11 @@ export default css`
 
   .horizon-card-field-moon-phase-icon {
     --mdc-icon-size: 2em;
-    color: var(--hc-moon-phase-icon-color);
+    color: var(--hc-moon-phase-icon-color, var(--primary-color));
   }
 
   .horizon-card-field-value-secondary {
-    color: var(--hc-field-value-secondary-color);
+    color: var(--hc-field-value-secondary-color, var(--hc-field-value-color, var(--hc-primary)));
     font-size: 0.7em;
   }
 
@@ -148,22 +138,22 @@ export default css`
   }
 
   .horizon-card-graph .horizon-card-daytime-past {
-    fill: var(--hc-daytime-past-color);
-    stroke: var(--hc-daytime-past-color);
+    fill: var(--hc-daytime-past-color, #8ebeeb);
+    stroke: var(--hc-daytime-past-color, #8ebeeb);
   }
 
   .horizon-card-graph .horizon-card-daytime-upcoming {
-    fill: var(--hc-daytime-upcoming-color);
-    stroke: var(--hc-daytime-upcoming-color);
+    fill: var(--hc-daytime-upcoming-color, transparent);
+    stroke: var(--hc-daytime-upcoming-color, transparent);
   }
 
   .horizon-card-graph .horizon-card-nighttime-past {
-    fill: var(--hc-nighttime-past-color);
-    stroke: var(--hc-nighttime-past-color);
+    fill: var(--hc-nighttime-past-color, #393b78);
+    stroke: var(--hc-nighttime-past-color, #393b78);
   }
 
   .horizon-card-graph .horizon-card-nighttime-upcoming {
-    fill: var(--hc-nighttime-upcoming-color);
-    stroke: var(--hc-nighttime-upcoming-color);
+    fill: var(--hc-nighttime-upcoming-color, transparent);
+    stroke: var(--hc-nighttime-upcoming-color, transparent);
   }
 `

--- a/src/components/horizonCard/HorizonCardGraph.ts
+++ b/src/components/horizonCard/HorizonCardGraph.ts
@@ -108,11 +108,11 @@ export class HorizonCardGraph {
         <line class="horizon-card-sunrise-line"
               x1="${this.sunPosition.sunriseX}" y1="3"
               x2="${this.sunPosition.sunriseX}" y2="72"
-              stroke="var(--hc-sunrise-line-color)"/>
+              stroke="var(--hc-sunrise-line-color, var(--hc-lines, var(--hc-accent)))"/>
         <line class="horizon-card-sunset-line"
               x1="${this.sunPosition.sunsetX}"
               y1="3" x2="${this.sunPosition.sunsetX}" y2="72"
-              stroke="var(--hc-sunset-line-color)"/>
+              stroke="var(--hc-sunset-line-color, var(--hc-lines, var(--hc-accent)))"/>
       </g>` : nothing}
 
       <!-- Main group that shifts up or down to center the horizon vertically -->
@@ -122,7 +122,7 @@ export class HorizonCardGraph {
         <use class="horizon-card-sun-path"
              href="#sun-path"
              fill="none"
-             stroke="var(--hc-sun-path-color)"/>
+             stroke="var(--hc-sun-path-color, var(--hc-lines, var(--hc-accent)))"/>
 
         <!-- Night, already passed: below the horizon, behind the sun (left of it) -->
         <path
@@ -154,12 +154,12 @@ export class HorizonCardGraph {
         <line class="horizon-card-horizon-line"
               x1="5" y1="${this.sunPosition.horizonY}"
               x2="545" y2="${this.sunPosition.horizonY}"
-              stroke="var(--hc-horizon-line-color)"/>
+              stroke="var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent)))"/>
 
         <!-- Time arrow: the direction the sun and moon travel across the sky -->
         <path class="horizon-card-time-arrow"
               d="M535 ${this.sunPosition.horizonY - 5} L545 ${this.sunPosition.horizonY} L535 ${this.sunPosition.horizonY + 5}"
-              stroke="var(--hc-time-arrow-color)" fill="none"/>
+              stroke="var(--hc-time-arrow-color, var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent))))" fill="none"/>
 
         ${showSun ? svg`
         <!-- Draw the sun -->
@@ -168,7 +168,7 @@ export class HorizonCardGraph {
           cy="${this.sunPosition.y}"
           r="${Constants.SUN_RADIUS}"
           stroke="none"
-          fill="var(--hc-sun-color)"/>` : nothing}
+          fill="var(--hc-sun-color, var(--_hc-sun-color))"/>` : nothing}
 
         ${this.debugSun()}
       </g>
@@ -194,15 +194,15 @@ export class HorizonCardGraph {
     const smallSpotR = Constants.MOON_RADIUS / 5
     const bigSpotR = Constants.MOON_RADIUS / 4
     const hugeSpotR = Constants.MOON_RADIUS / 3
-    const spotFill = 'var(--hc-moon-spot-color)'
+    const spotFill = 'var(--hc-moon-spot-color, rgba(170, 170, 170, 0.1))'
     return this.config.moon ?
       svg`<!-- Moon -->
           <g class="horizon-card-moon">
           <g transform="rotate(${this.moonData.zenithAngle} ${this.moonPosition.x} ${this.moonPosition.y})">
             <!-- Moon shadow -->
-            <use class="horizon-card-moon-shadow" href="#moon" fill="var(--hc-moon-shadow-color)"/>
+            <use class="horizon-card-moon-shadow" href="#moon" fill="var(--hc-moon-shadow-color, var(--_hc-moon-shadow-color))"/>
             <!-- Moon proper -->
-            <use class="horizon-card-moon-body" href="#moon" fill="var(--hc-moon-color)" mask="url(#moon-shadow-mask)"/>
+            <use class="horizon-card-moon-body" href="#moon" fill="var(--hc-moon-color, var(--_hc-moon-color))" mask="url(#moon-shadow-mask)"/>
           </g>
           <!-- Moon spots to approximate the darker parts -->
           <g class="horizon-card-moon-spots" transform="rotate(${this.moonData.parallacticAngle} ${this.moonPosition.x} ${this.moonPosition.y})">
@@ -219,7 +219,7 @@ export class HorizonCardGraph {
           <circle class="horizon-card-moon-outline"
                   cx="${this.moonPosition.x}" cy="${this.moonPosition.y}"
                   r="${Constants.MOON_RADIUS}" fill="none"
-                  stroke="var(--hc-moon-outline-color)" stroke-width="0.7"/>
+                  stroke="var(--hc-moon-outline-color, var(--_hc-moon-outline-color))" stroke-width="0.7"/>
           </g>
         ` : nothing
   }

--- a/tests/unit/components/horizonCard/__snapshots__/HorizonCardGraph.spec.ts.snap
+++ b/tests/unit/components/horizonCard/__snapshots__/HorizonCardGraph.spec.ts.snap
@@ -89,7 +89,7 @@ exports[`HorizonCardGraph render does not render the moon when not configured so
       <line class="horizon-card-sunrise-line"
             y1="3"
             y2="72"
-            stroke="var(--hc-sunrise-line-color)"
+            stroke="var(--hc-sunrise-line-color, var(--hc-lines, var(--hc-accent)))"
             x1="0"
             x2="0"
       >
@@ -97,7 +97,7 @@ exports[`HorizonCardGraph render does not render the moon when not configured so
       <line class="horizon-card-sunset-line"
             y1="3"
             y2="72"
-            stroke="var(--hc-sunset-line-color)"
+            stroke="var(--hc-sunset-line-color, var(--hc-lines, var(--hc-accent)))"
             x1="0"
             x2="0"
       >
@@ -109,7 +109,7 @@ exports[`HorizonCardGraph render does not render the moon when not configured so
       <use class="horizon-card-sun-path"
            href="#sun-path"
            fill="none"
-           stroke="var(--hc-sun-path-color)"
+           stroke="var(--hc-sun-path-color, var(--hc-lines, var(--hc-accent)))"
       >
       </use>
       <path clip-path="url(#lower-path-mask)"
@@ -137,20 +137,20 @@ exports[`HorizonCardGraph render does not render the moon when not configured so
       <line class="horizon-card-horizon-line"
             x1="5"
             x2="545"
-            stroke="var(--hc-horizon-line-color)"
+            stroke="var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent)))"
             y1="0"
             y2="0"
       >
       </line>
       <path class="horizon-card-time-arrow"
-            stroke="var(--hc-time-arrow-color)"
+            stroke="var(--hc-time-arrow-color, var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent))))"
             fill="none"
             d="M535 -5 L545 0 L535 5"
       >
       </path>
       <circle class="horizon-card-sun"
               stroke="none"
-              fill="var(--hc-sun-color)"
+              fill="var(--hc-sun-color, var(--_hc-sun-color))"
               cx="0"
               cy="0"
               r="17"
@@ -249,13 +249,13 @@ exports[`HorizonCardGraph render does not render the sun when not configured so 
       <line class="horizon-card-horizon-line"
             x1="5"
             x2="545"
-            stroke="var(--hc-horizon-line-color)"
+            stroke="var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent)))"
             y1="0"
             y2="0"
       >
       </line>
       <path class="horizon-card-time-arrow"
-            stroke="var(--hc-time-arrow-color)"
+            stroke="var(--hc-time-arrow-color, var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent))))"
             fill="none"
             d="M535 -5 L545 0 L535 5"
       >
@@ -354,7 +354,7 @@ exports[`HorizonCardGraph render renders the graph with the data values when pro
       <line class="horizon-card-sunrise-line"
             y1="3"
             y2="72"
-            stroke="var(--hc-sunrise-line-color)"
+            stroke="var(--hc-sunrise-line-color, var(--hc-lines, var(--hc-accent)))"
             x1="200"
             x2="200"
       >
@@ -362,7 +362,7 @@ exports[`HorizonCardGraph render renders the graph with the data values when pro
       <line class="horizon-card-sunset-line"
             y1="3"
             y2="72"
-            stroke="var(--hc-sunset-line-color)"
+            stroke="var(--hc-sunset-line-color, var(--hc-lines, var(--hc-accent)))"
             x1="400"
             x2="400"
       >
@@ -374,7 +374,7 @@ exports[`HorizonCardGraph render renders the graph with the data values when pro
       <use class="horizon-card-sun-path"
            href="#sun-path"
            fill="none"
-           stroke="var(--hc-sun-path-color)"
+           stroke="var(--hc-sun-path-color, var(--hc-lines, var(--hc-accent)))"
       >
       </use>
       <path clip-path="url(#lower-path-mask)"
@@ -402,20 +402,20 @@ exports[`HorizonCardGraph render renders the graph with the data values when pro
       <line class="horizon-card-horizon-line"
             x1="5"
             x2="545"
-            stroke="var(--hc-horizon-line-color)"
+            stroke="var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent)))"
             y1="84"
             y2="84"
       >
       </line>
       <path class="horizon-card-time-arrow"
-            stroke="var(--hc-time-arrow-color)"
+            stroke="var(--hc-time-arrow-color, var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent))))"
             fill="none"
             d="M535 79 L545 84 L535 89"
       >
       </path>
       <circle class="horizon-card-sun"
               stroke="none"
-              fill="var(--hc-sun-color)"
+              fill="var(--hc-sun-color, var(--_hc-sun-color))"
               cx="50"
               cy="50"
               r="17"
@@ -426,12 +426,12 @@ exports[`HorizonCardGraph render renders the graph with the data values when pro
       <g transform="rotate(0 100 25)">
         <use class="horizon-card-moon-shadow"
              href="#moon"
-             fill="var(--hc-moon-shadow-color)"
+             fill="var(--hc-moon-shadow-color, var(--_hc-moon-shadow-color))"
         >
         </use>
         <use class="horizon-card-moon-body"
              href="#moon"
-             fill="var(--hc-moon-color)"
+             fill="var(--hc-moon-color, var(--_hc-moon-color))"
              mask="url(#moon-shadow-mask)"
         >
         </use>
@@ -443,34 +443,34 @@ exports[`HorizonCardGraph render renders the graph with the data values when pro
                 cx="96.5"
                 cy="19.75"
                 r="4.666666666666667"
-                fill="var(--hc-moon-spot-color)"
+                fill="var(--hc-moon-spot-color, rgba(170, 170, 170, 0.1))"
         >
         </circle>
         <circle stroke="none"
                 cx="105.25"
                 cy="18"
                 r="3.5"
-                fill="var(--hc-moon-spot-color)"
+                fill="var(--hc-moon-spot-color, rgba(170, 170, 170, 0.1))"
         >
         </circle>
         <circle stroke="none"
                 cx="96.5"
                 cy="28.5"
                 r="3.5"
-                fill="var(--hc-moon-spot-color)"
+                fill="var(--hc-moon-spot-color, rgba(170, 170, 170, 0.1))"
         >
         </circle>
         <circle stroke="none"
                 cx="107"
                 cy="25"
                 r="2.8"
-                fill="var(--hc-moon-spot-color)"
+                fill="var(--hc-moon-spot-color, rgba(170, 170, 170, 0.1))"
         >
         </circle>
       </g>
       <circle class="horizon-card-moon-outline"
               fill="none"
-              stroke="var(--hc-moon-outline-color)"
+              stroke="var(--hc-moon-outline-color, var(--_hc-moon-outline-color))"
               stroke-width="0.7"
               cx="100"
               cy="25"
@@ -571,7 +571,7 @@ exports[`HorizonCardGraph render renders the graph with the default values when 
       <line class="horizon-card-sunrise-line"
             y1="3"
             y2="72"
-            stroke="var(--hc-sunrise-line-color)"
+            stroke="var(--hc-sunrise-line-color, var(--hc-lines, var(--hc-accent)))"
             x1="0"
             x2="0"
       >
@@ -579,7 +579,7 @@ exports[`HorizonCardGraph render renders the graph with the default values when 
       <line class="horizon-card-sunset-line"
             y1="3"
             y2="72"
-            stroke="var(--hc-sunset-line-color)"
+            stroke="var(--hc-sunset-line-color, var(--hc-lines, var(--hc-accent)))"
             x1="0"
             x2="0"
       >
@@ -591,7 +591,7 @@ exports[`HorizonCardGraph render renders the graph with the default values when 
       <use class="horizon-card-sun-path"
            href="#sun-path"
            fill="none"
-           stroke="var(--hc-sun-path-color)"
+           stroke="var(--hc-sun-path-color, var(--hc-lines, var(--hc-accent)))"
       >
       </use>
       <path clip-path="url(#lower-path-mask)"
@@ -619,20 +619,20 @@ exports[`HorizonCardGraph render renders the graph with the default values when 
       <line class="horizon-card-horizon-line"
             x1="5"
             x2="545"
-            stroke="var(--hc-horizon-line-color)"
+            stroke="var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent)))"
             y1="0"
             y2="0"
       >
       </line>
       <path class="horizon-card-time-arrow"
-            stroke="var(--hc-time-arrow-color)"
+            stroke="var(--hc-time-arrow-color, var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent))))"
             fill="none"
             d="M535 -5 L545 0 L535 5"
       >
       </path>
       <circle class="horizon-card-sun"
               stroke="none"
-              fill="var(--hc-sun-color)"
+              fill="var(--hc-sun-color, var(--_hc-sun-color))"
               cx="0"
               cy="0"
               r="17"
@@ -643,12 +643,12 @@ exports[`HorizonCardGraph render renders the graph with the default values when 
       <g transform="rotate(0 0 0)">
         <use class="horizon-card-moon-shadow"
              href="#moon"
-             fill="var(--hc-moon-shadow-color)"
+             fill="var(--hc-moon-shadow-color, var(--_hc-moon-shadow-color))"
         >
         </use>
         <use class="horizon-card-moon-body"
              href="#moon"
-             fill="var(--hc-moon-color)"
+             fill="var(--hc-moon-color, var(--_hc-moon-color))"
              mask="url(#moon-shadow-mask)"
         >
         </use>
@@ -660,34 +660,34 @@ exports[`HorizonCardGraph render renders the graph with the default values when 
                 cx="-3.5"
                 cy="-5.25"
                 r="4.666666666666667"
-                fill="var(--hc-moon-spot-color)"
+                fill="var(--hc-moon-spot-color, rgba(170, 170, 170, 0.1))"
         >
         </circle>
         <circle stroke="none"
                 cx="5.25"
                 cy="-7"
                 r="3.5"
-                fill="var(--hc-moon-spot-color)"
+                fill="var(--hc-moon-spot-color, rgba(170, 170, 170, 0.1))"
         >
         </circle>
         <circle stroke="none"
                 cx="-3.5"
                 cy="3.5"
                 r="3.5"
-                fill="var(--hc-moon-spot-color)"
+                fill="var(--hc-moon-spot-color, rgba(170, 170, 170, 0.1))"
         >
         </circle>
         <circle stroke="none"
                 cx="7"
                 cy="0"
                 r="2.8"
-                fill="var(--hc-moon-spot-color)"
+                fill="var(--hc-moon-spot-color, rgba(170, 170, 170, 0.1))"
         >
         </circle>
       </g>
       <circle class="horizon-card-moon-outline"
               fill="none"
-              stroke="var(--hc-moon-outline-color)"
+              stroke="var(--hc-moon-outline-color, var(--_hc-moon-outline-color))"
               stroke-width="0.7"
               cx="0"
               cy="0"
@@ -788,7 +788,7 @@ exports[`HorizonCardGraph renders the graph flipped horizontally when configured
       <line class="horizon-card-sunrise-line"
             y1="3"
             y2="72"
-            stroke="var(--hc-sunrise-line-color)"
+            stroke="var(--hc-sunrise-line-color, var(--hc-lines, var(--hc-accent)))"
             x1="0"
             x2="0"
       >
@@ -796,7 +796,7 @@ exports[`HorizonCardGraph renders the graph flipped horizontally when configured
       <line class="horizon-card-sunset-line"
             y1="3"
             y2="72"
-            stroke="var(--hc-sunset-line-color)"
+            stroke="var(--hc-sunset-line-color, var(--hc-lines, var(--hc-accent)))"
             x1="0"
             x2="0"
       >
@@ -808,7 +808,7 @@ exports[`HorizonCardGraph renders the graph flipped horizontally when configured
       <use class="horizon-card-sun-path"
            href="#sun-path"
            fill="none"
-           stroke="var(--hc-sun-path-color)"
+           stroke="var(--hc-sun-path-color, var(--hc-lines, var(--hc-accent)))"
       >
       </use>
       <path clip-path="url(#lower-path-mask)"
@@ -836,20 +836,20 @@ exports[`HorizonCardGraph renders the graph flipped horizontally when configured
       <line class="horizon-card-horizon-line"
             x1="5"
             x2="545"
-            stroke="var(--hc-horizon-line-color)"
+            stroke="var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent)))"
             y1="0"
             y2="0"
       >
       </line>
       <path class="horizon-card-time-arrow"
-            stroke="var(--hc-time-arrow-color)"
+            stroke="var(--hc-time-arrow-color, var(--hc-horizon-line-color, var(--hc-lines, var(--hc-accent))))"
             fill="none"
             d="M535 -5 L545 0 L535 5"
       >
       </path>
       <circle class="horizon-card-sun"
               stroke="none"
-              fill="var(--hc-sun-color)"
+              fill="var(--hc-sun-color, var(--_hc-sun-color))"
               cx="0"
               cy="0"
               r="17"

--- a/tests/visual/theme-vars.spec.ts
+++ b/tests/visual/theme-vars.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test'
+
+declare global {
+  interface Window {
+    renderCard: (config: Record<string, unknown>) => Promise<unknown>
+  }
+}
+
+// Proves the themeable-variable fix: a graph colour resolves — through the use-site
+// var(--token, fallback) chain — from a Home Assistant theme (a value set on an ancestor of the
+// card host, like :root), from card-mod/Uix (a value on ha-card inside the shadow), and from the
+// built-in default. Before the fix the tokens were declared on :host, which masked the theme case.
+
+const GRAPH_ONLY = { fields: false }
+
+async function strokeOf (page, selector: string) {
+  return page.evaluate((sel) => {
+    const card = document.getElementById('card') as HTMLElement & { shadowRoot: ShadowRoot }
+    const el = card.shadowRoot.querySelector(sel)
+    return el ? getComputedStyle(el).stroke : null
+  }, selector)
+}
+
+test.describe('themeable graph colours', () => {
+  test('default resolves to the accent colour', async ({ page }) => {
+    await page.goto('/tests/visual/harness.html')
+    await page.evaluate((c) => window.renderCard(c), GRAPH_ONLY)
+    expect(await strokeOf(page, '.horizon-card-sunrise-line')).toBe('rgb(215, 215, 215)') // #d7d7d7
+  })
+
+  test('a theme value on an ancestor (like :root) applies', async ({ page }) => {
+    await page.goto('/tests/visual/harness.html')
+    await page.addStyleTag({ content: '#container { --hc-sunrise-line-color: rgb(255, 0, 0); }' })
+    await page.evaluate((c) => window.renderCard(c), GRAPH_ONLY)
+    expect(await strokeOf(page, '.horizon-card-sunrise-line')).toBe('rgb(255, 0, 0)')
+  })
+
+  test('a card-mod value on ha-card applies', async ({ page }) => {
+    await page.goto('/tests/visual/harness.html')
+    await page.evaluate((c) => window.renderCard(c), GRAPH_ONLY)
+    await page.evaluate(() => {
+      const card = document.getElementById('card') as HTMLElement & { shadowRoot: ShadowRoot }
+      const haCard = card.shadowRoot.querySelector('ha-card') as HTMLElement
+      haCard.style.setProperty('--hc-sunrise-line-color', 'rgb(0, 0, 255)')
+    })
+    expect(await strokeOf(page, '.horizon-card-sunrise-line')).toBe('rgb(0, 0, 255)')
+  })
+
+  test('the time arrow defaults to the horizon-line colour', async ({ page }) => {
+    await page.goto('/tests/visual/harness.html')
+    // Only the horizon-line colour is set (not the arrow's own) — the arrow should follow it.
+    await page.addStyleTag({ content: '#container { --hc-horizon-line-color: rgb(0, 128, 0); }' })
+    await page.evaluate((c) => window.renderCard(c), GRAPH_ONLY)
+    expect(await strokeOf(page, '.horizon-card-time-arrow')).toBe('rgb(0, 128, 0)')
+  })
+})


### PR DESCRIPTION
Makes the `--hc-*` graph colours actually themeable from a Home Assistant theme (not just card-mod), and defaults the time arrow to the horizon-line colour.

Fixes #228. Addresses the last two comments on #219.

## The bug (#228)

Setting the line colours in a **Home Assistant theme** did nothing, even though the README documents it; only a card-mod/Uix override on `ha-card` worked.

**Root cause:** the tokens were declared on `:host` (`:host { --hc-sunrise-line-color: var(--hc-lines) }`). A declaration on `:host` wins over a value inherited from an ancestor, and HA applies theme variables on the document root — an **ancestor** of the card host. So the `:host` declaration masked the theme value; the SVG inherited the card's own default. card-mod works only because it sets the variable on `ha-card`, a **descendant** of the host, closer to the SVG in the cascade.

This affected every `--hc-*` colour, so the whole "set them from a theme" section was effectively broken.

## The fix

Consume each colour at its point of use with a fallback and stop declaring the public tokens on `:host`:

```
stroke="var(--hc-sunrise-line-color, var(--hc-lines, var(--hc-accent)))"
```

Now a **theme** (ancestor / `:root`), a **card-mod/Uix** override on `ha-card`, a **per-element** override, and the **default** all resolve. This is [Lit's recommended pattern](https://lit.dev/docs/components/styles/); the [private-alias variant](https://web.dev/articles/custom-properties-web-components) (alias on `:host`) would have re-broken the element-level overrides people already use, because `ha-card` sits below `:host`. Only internal seeds stay on `:host`: the dark-mode-aware `--hc-accent` and the computed `--_hc-*` body colours.

## Arrow default (#219)

The time arrow now defaults to `--hc-horizon-line-color` (it is the arrowhead at the end of the horizon line), while still being independently settable via `--hc-time-arrow-color`.

## Verification

- **Default render is byte-identical** — every fallback resolves to the previous value, so all 9 visual screenshot baselines are unchanged.
- A new **Playwright test** (`tests/visual/theme-vars.spec.ts`) reads the computed stroke and proves: default = accent (`rgb(215,215,215)`); a theme value on an ancestor applies; a card-mod value on `ha-card` applies; and the arrow follows the horizon-line colour.
- `docker/run.sh` green (756 unit tests), visual suite green (13, incl. the 4 proofs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
