### PR TITLE
Log a version signature to the console on load (#227)

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -62,6 +62,10 @@ jobs:
       - name: Build
         run: yarn build
 
+      # Replace the __HORIZON_CARD_VERSION__ placeholder (see src/index.ts) with the chosen tag.
+      - name: Stamp the release version into the bundle
+        run: sed -i "s|__HORIZON_CARD_VERSION__|${{ inputs.version }}|g" dist/lovelace-horizon-card.js
+
       - name: Create pre-release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,12 @@ jobs:
           echo "Created tag name: ${{ steps.release.outputs.tag_name }}"
           echo "Created release version: ${{ steps.release.outputs.version }}"
 
+      # The bundle carries a __HORIZON_CARD_VERSION__ placeholder (see src/index.ts). The version is
+      # only known here, after the release action computed the tag, so stamp it in before uploading.
+      - name: Stamp the release version into the bundle
+        if: ${{ steps.release.outputs.version != '' }}
+        run: sed -i "s|__HORIZON_CARD_VERSION__|${{ steps.release.outputs.tag_name }}|g" dist/lovelace-horizon-card.js
+
       - name: Upload JS card file to release
         if: ${{ steps.release.outputs.version != '' }}
         uses: svenstaro/upload-release-action@v2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lovelace-horizon-card",
-  "version": "1.1.0",
+  "version": "0.0.0",
   "packageManager": "yarn@4.5.1",
   "description": "Successor to Sun Card - Visualize the position of the sun over the horizon",
   "type": "commonjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,17 @@
 import './components/horizonCard'
+
+// The placeholder below is replaced with the git tag by the release CI (see the "Stamp the release
+// version" steps in .github/workflows/release.yaml and prerelease.yaml), since the version lives in
+// the GitHub tag, not package.json. A local or dev build keeps the placeholder and reports "dev".
+// It must survive bundling verbatim, so keep it a plain string literal (the build has no minifier).
+const CARD_VERSION = '__HORIZON_CARD_VERSION__'
+const version = CARD_VERSION.startsWith('__') ? 'dev' : CARD_VERSION
+const REPOSITORY = 'https://github.com/rejuvenate/lovelace-horizon-card'
+
+// eslint-disable-next-line no-console
+console.info(
+  `%c🌅 HORIZON-CARD %c ${version} %c ${REPOSITORY}`,
+  'color:#fff;background:#3b5566;font-weight:bold;padding:2px 6px;border-radius:5px 0 0 5px',
+  'color:#222;background:#f5cb5c;font-weight:bold;padding:2px 6px;border-radius:0 5px 5px 0',
+  'color:inherit;background:none'
+)

--- a/tests/visual/console-signature.spec.ts
+++ b/tests/visual/console-signature.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+// The bundle logs a name + version signature to the console when it loads (#227), so a user can
+// confirm the resource loaded and which version. A local/CI build leaves the version placeholder
+// unstamped and reports "dev"; the release CI replaces it with the git tag.
+test('logs a version signature to the console on load', async ({ page }) => {
+  const messages: string[] = []
+  page.on('console', (msg) => messages.push(msg.text()))
+
+  await page.goto('/tests/visual/harness.html')
+  await page.waitForFunction(() => Array.isArray((window as { customCards?: unknown[] }).customCards))
+
+  const signature = messages.find((m) => m.toUpperCase().includes('HORIZON-CARD'))
+  expect(signature).toBeTruthy()
+  expect(signature).toContain('dev')
+  // The repository link is included for identification and issue tracking.
+  expect(signature).toContain('https://github.com/rejuvenate/lovelace-horizon-card')
+})


### PR DESCRIPTION
Logs a name + version signature to the console when the card loads, so users can confirm the resource loaded and which version they're on. Fixes #227.

```
🌅 HORIZON-CARD  v2.0.0
```

## The version had to be solved first

`package.json` was a stale `1.1.0` that no workflow ever touched: the release flow uses `release-on-push-action`, which is deliberately package.json-agnostic — the **git tag is the source of truth**. And the stable build runs *before* the release action computes the tag, so the bundle can't read its own version at build time.

So the version is **stamped into the bundle by CI**:
- `src/index.ts` carries a `__HORIZON_CARD_VERSION__` placeholder; the console log shows it, falling back to `dev` when it's still the placeholder (local / `docker` builds).
- `release.yaml` and `prerelease.yaml` `sed` the placeholder to the tag before uploading the asset (stable: after the release action computes it; beta: from the workflow input).
- `package.json` `version` is set to `0.0.0` since it is not, and cannot be, the source of truth here.

This keeps your `release:*`-label, tag-based release flow untouched (no version-bump commits, no new deps).

## Verified on the real bundle

- The placeholder survives bundling (`grep` count 1), the `sed` removes it and stamps the version, and the signature reads `version` at runtime (`var version = CARD_VERSION.startsWith('__') ? 'dev' : CARD_VERSION`), so the stamp genuinely drives what's shown — not folded to `dev` at build time.
- A Playwright test (`tests/visual/console-signature.spec.ts`) loads the card and asserts the signature is logged, reporting `dev` for the unstamped build.
- `docker/run.sh` green, visual suite green, no render changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
