### PR TITLE
Document common styling recipes and add small-screen dashboard cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,82 @@ By default the graph crops its height to fit the Sun and Moon, so there are no l
 
 Set a number to pin one or both sides (for example `--hc-graph-above-horizon: 55`). To turn the fitting off and keep the classic fixed frame, set `--hc-graph-above-horizon: 84` and `--hc-graph-below-horizon: 66`.
 
+**Common recipes**
+
+A few tweaks that come up often. Colours are `--hc-*` variables, so they work in a theme or in Uix/card-mod. Anything that is not a colour (text case, font size, line thickness) is an ordinary CSS property, so it needs Uix or card-mod rather than a theme.
+
+Title-case the field names, so `sunrise` reads as `Sunrise`:
+
+```yaml
+uix:
+  style: |
+    .horizon-card-field-name {
+      text-transform: capitalize;
+    }
+```
+
+Make the text bigger. The card is sized in `em`, so one rule scales all of it:
+
+```yaml
+uix:
+  style: |
+    .horizon-card {
+      font-size: 1.2em;
+    }
+```
+
+Thicker graph lines, which helps on dark themes and low-contrast or e-ink screens. The width is in viewBox units (the graph is 550 wide) and the default is `1`:
+
+```yaml
+uix:
+  style: |
+    .horizon-card-sun-path,
+    .horizon-card-horizon-line,
+    .horizon-card-sunrise-line,
+    .horizon-card-sunset-line {
+      stroke-width: 2px;
+    }
+```
+
+Darken the shadowed side of the Moon. This is a colour, so a theme works too:
+
+```yaml
+# in a theme
+hc-moon-shadow-color: "#111111"
+```
+
+```yaml
+# or on a single card
+uix:
+  style: |
+    ha-card {
+      --hc-moon-shadow-color: #111111;
+    }
+```
+
+Recolour the small Moon-phase icon shown with the fields:
+
+```yaml
+uix:
+  style: |
+    ha-card {
+      --hc-moon-phase-icon-color: #4fc3f7;
+    }
+```
+
+To hide the sunrise and sunset lines outright, use `sunrise_sunset_lines: false`. To do it in CSS instead, for example to switch them off only under one theme, set their colour to transparent:
+
+```yaml
+uix:
+  style: |
+    ha-card {
+      --hc-sunrise-line-color: transparent;
+      --hc-sunset-line-color: transparent;
+    }
+```
+
+Every drawn element has a stable class, all of them listed in [`tests/manual/styling-and-embedding.yaml`](tests/manual/styling-and-embedding.yaml), so you can target any part the same way.
+
 ## Development
 
 ### Prepare the environment

--- a/tests/manual/styling-and-embedding.yaml
+++ b/tests/manual/styling-and-embedding.yaml
@@ -651,3 +651,105 @@ views:
               ## Q. Stable class hooks
 
               Every drawn element carries a stable class for card-mod or theme targeting. In the graph: `.horizon-card-graph`, `.horizon-card-sun-path`, `.horizon-card-horizon-line`, `.horizon-card-time-arrow`, `.horizon-card-sunrise-line`, `.horizon-card-sunset-line`, `.horizon-card-daytime` and `.horizon-card-nighttime` (each split into `-past` behind the sun and `-upcoming` ahead of it), `.horizon-card-sun` and `.horizon-card-moon` (with `-body`, `-shadow`, `-spots` and `-outline` sub-parts). Around the values: `.card-header`, `.horizon-card-header`, `.horizon-card-footer`, `.horizon-card-field-row` and `.horizon-card-field-<name>`. The card wrapper is `.horizon-card` (also `.card-content`).
+
+      # ---------------------------------------------------------------------
+      # R. Common recipes
+      # ---------------------------------------------------------------------
+      - type: vertical-stack
+        cards:
+          - type: markdown
+            content: |
+              ## R. Common recipes
+
+              The frequently asked tweaks from the README, next to a default card for comparison. Colours can also live in a theme; the non-colour ones (text case, font size, line width) need Uix or card-mod.
+          - type: markdown
+            content: "**R1** default, for reference."
+          - type: custom:horizon-card
+            fields:
+              azimuth: true
+              elevation: true
+          - type: markdown
+            content: "**R2** title-cased field names (`text-transform: capitalize`)."
+          - type: custom:horizon-card
+            fields:
+              azimuth: true
+              elevation: true
+            uix:
+              style: |
+                .horizon-card-field-name {
+                  text-transform: capitalize;
+                }
+          - type: markdown
+            content: "**R3** larger text (`font-size: 1.2em` on `.horizon-card`)."
+          - type: custom:horizon-card
+            fields:
+              azimuth: true
+              elevation: true
+            uix:
+              style: |
+                .horizon-card {
+                  font-size: 1.2em;
+                }
+          - type: markdown
+            content: "**R4** thicker graph lines (`stroke-width: 2px`), easier to read on dark or e-ink screens."
+          - type: custom:horizon-card
+            fields: false
+            uix:
+              style: |
+                .horizon-card-sun-path,
+                .horizon-card-horizon-line,
+                .horizon-card-sunrise-line,
+                .horizon-card-sunset-line {
+                  stroke-width: 2px;
+                }
+          - type: markdown
+            content: "**R5** sunrise and sunset lines hidden via CSS (their colour set to `transparent`); `sunrise_sunset_lines: false` does the same as an option."
+          - type: custom:horizon-card
+            fields: false
+            uix:
+              style: |
+                ha-card {
+                  --hc-sunrise-line-color: transparent;
+                  --hc-sunset-line-color: transparent;
+                }
+
+      # ---------------------------------------------------------------------
+      # S. Narrow width (small screen)
+      # ---------------------------------------------------------------------
+      - type: vertical-stack
+        cards:
+          - type: markdown
+            content: |
+              ## S. Narrow width (small screen)
+
+              The card reports `min_columns: 6` and sizes to its content, so in a Sections view it reflows and fills like other cards. On a very narrow column the field row does not wrap, so the values sit close together. These cards are pinned to phone-like widths to check that crowding; resize the window or open it on a phone to see the real grid behaviour.
+          - type: markdown
+            content: "**S1** about a two-column phone width (250px), default fields."
+          - type: custom:horizon-card
+            uix:
+              style: |
+                ha-card {
+                  max-width: 250px;
+                }
+          - type: markdown
+            content: "**S2** the same width with all fields, the busiest case."
+          - type: custom:horizon-card
+            fields:
+              azimuth: true
+              elevation: true
+              moonrise: true
+              moonset: true
+              moon_phase: true
+            uix:
+              style: |
+                ha-card {
+                  max-width: 250px;
+                }
+          - type: markdown
+            content: "**S3** very narrow (180px), where the fields crowd the most."
+          - type: custom:horizon-card
+            uix:
+              style: |
+                ha-card {
+                  max-width: 180px;
+                }


### PR DESCRIPTION
Pulls the tweaks people ask for most into one **Common recipes** block in the README styling section, so the answers are copy-paste instead of scattered across issues.

Recipes covered:
- Title-case field names (`text-transform: capitalize`)
- Bigger text (one `font-size` on `.horizon-card`)
- Thicker graph lines (`stroke-width`), for dark and e-ink screens
- Darker Moon shadow (`--hc-moon-shadow-color`, theme or card-mod)
- Moon phase icon colour (`--hc-moon-phase-icon-color`)
- Hiding the sunrise/sunset markers (their colour set to `transparent`)

Each notes whether it works in a plain theme (the `--hc-*` colours do) or needs Uix/card-mod (anything that is not a colour).

The manual dashboard gets a matching **R. Common recipes** section (the same tweaks shown next to a default card) and an **S. Narrow width** section that pins cards to phone-like widths, so the small-screen field crowding is easy to eyeball.

Closes some long-standing doc requests and gives ready answers for a few open ones: #65, #116, #64, #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
