### PR TITLE
Add dev/ha-live: verify Lovelace artifacts in a real Home Assistant

### DIFF
--- a/dev/ha-live/.gitignore
+++ b/dev/ha-live/.gitignore
@@ -1,0 +1,4 @@
+# verify.sh generates config/ fresh each run (HA config + the copied dashboard + the card bundle) and
+# HA writes its runtime state there, so the whole directory is ephemeral. (Screenshot output under
+# out/ is already ignored by the repo-root .gitignore.)
+/config/

--- a/dev/ha-live/README.md
+++ b/dev/ha-live/README.md
@@ -1,0 +1,72 @@
+# dev/ha-live - verify artifacts in a real Home Assistant
+
+Spin up a real, pinned Home Assistant in Docker, install the built card, load a Lovelace artifact
+(a dashboard, a single card, or the visual editor), and screenshot it headless. This is the
+faithful counterpart to the automated `tests/visual/` suite, which renders against a stubbed
+frontend: some things (real theming, `ha-form`, Uix / card-mod styling, embedding, the visual
+editor) only render truthfully inside an actual Home Assistant.
+
+It replaces the hand ritual documented in [`tests/manual/README.md`](../../tests/manual/README.md)
+(build, add the resource, paste the 755-line dashboard into the Raw configuration editor) with one
+command. Everything runs in Docker, so nothing (Home Assistant, node, browsers) is installed on the
+host. It is **not** part of CI - run it on demand.
+
+## Requirements
+
+Docker with the Compose plugin. That's it.
+
+## Usage
+
+```bash
+# The manual test dashboard (default target): every option, styling hook and embedding case.
+dev/ha-live/verify.sh
+
+# Any dashboard YAML (a full Lovelace config with title + views).
+dev/ha-live/verify.sh --dashboard path/to/dashboard.yaml
+
+# A single card config, wrapped in a one-card dashboard.
+dev/ha-live/verify.sh --card path/to/card.yaml
+
+# The card's visual editor (needs a bundle that ships getConfigElement).
+dev/ha-live/verify.sh --editor
+
+# Include an extra Lovelace resource (e.g. Uix, so the styling-example cards apply their mods).
+dev/ha-live/verify.sh --resource /local/uix.js
+
+# Leave HA running and open http://localhost:8123 to click around (user "dev", pass "ha-live-dev").
+dev/ha-live/verify.sh --keep
+```
+
+Options: `--dashboard <path>` (default `tests/manual/styling-and-embedding.yaml`), `--card <path>`,
+`--editor [<type>]` (default `horizon-card`), `--resource url[,type]` (repeatable, default type
+`module`), `--ha-version <tag>`, `--out <dir>` (default `dev/ha-live/out`), `--keep`.
+
+Screenshots and a `report.json` (mode, screenshots, any uncaught page errors, recorded console
+errors) land in `dev/ha-live/out/`.
+
+## What it does
+
+1. Builds `dist/lovelace-horizon-card.js` in the project's Docker image and copies it where HA serves
+   it (`/local/...`).
+2. Generates a clean HA config: `default_config` plus YAML-mode Lovelace whose `resources:` load the
+   card (and any `--resource`), with the target as the `ui-lovelace.yaml` dashboard.
+3. Starts the pinned HA (`docker compose`), on a private network - the host port is **not** published
+   unless you pass `--keep`, so it never collides with a Home Assistant you already run on 8123.
+4. A Playwright driver container (on the same network) waits for HA, finishes onboarding over the API,
+   logs in, and screenshots the target. It fails the run on an uncaught page error, a failed login,
+   or no card rendering; benign HA console warnings are only recorded.
+5. Tears everything down (unless `--keep`).
+
+## Notes
+
+- The Home Assistant version is pinned in `docker-compose.yml` (never `latest`/`stable`); bump it
+  deliberately or pass `--ha-version`.
+- Styling-example cards that use [Uix](https://github.com/Lint-Free-Technology/uix) (or card-mod)
+  render **unstyled** unless you load that resource with `--resource`; the card itself renders
+  regardless.
+- `--editor` only produces a screenshot when the built bundle ships a visual editor
+  (`getConfigElement`). On `main` it is a documented mode; it works once PR #235 (the visual editor)
+  is in the build.
+- `driver.mjs` is bind-mounted into the image, so you can iterate on the driver without rebuilding.
+- `config/` is regenerated from scratch on every run (HA writes its runtime state there); it is
+  git-ignored.

--- a/dev/ha-live/docker-compose.keep.yml
+++ b/dev/ha-live/docker-compose.keep.yml
@@ -1,0 +1,8 @@
+# Overlay used by `verify.sh --keep`: publishes the Home Assistant port on the host so you can open
+# http://localhost:8123 and inspect the instance by hand. The headless default does not publish it
+# (the driver reaches HA over the compose network), so it never collides with a Home Assistant you
+# may already be running on 8123.
+services:
+  homeassistant:
+    ports:
+      - '8123:8123'

--- a/dev/ha-live/docker-compose.yml
+++ b/dev/ha-live/docker-compose.yml
@@ -1,0 +1,16 @@
+# Real Home Assistant for verifying Lovelace artifacts of this card (dashboards, single cards, the
+# visual editor). Driven by dev/ha-live/verify.sh; not part of CI. Pin an EXACT Home Assistant
+# version (never latest/stable) so behaviour is reproducible; bump it deliberately (or pass
+# --ha-version, which sets HA_IMAGE).
+#
+# `name:` pins the compose project so the network is always `ha-live_default`, which the Playwright
+# driver container joins to reach this service at http://homeassistant:8123. The host port is NOT
+# published here so a Home Assistant you may already run on 8123 is never disturbed; verify.sh
+# --keep adds it via docker-compose.keep.yml for manual inspection.
+name: ha-live
+services:
+  homeassistant:
+    image: ${HA_IMAGE:-ghcr.io/home-assistant/home-assistant:2025.12}
+    container_name: ha-live
+    volumes:
+      - ./config:/config

--- a/dev/ha-live/driver.mjs
+++ b/dev/ha-live/driver.mjs
@@ -1,0 +1,190 @@
+// Playwright driver for dev/ha-live/verify.sh. Runs inside the horizon-card-visual image (which has
+// Playwright + a matching Chromium), joined to the compose network so it reaches Home Assistant at
+// http://homeassistant:8123. It waits for HA, finishes onboarding over the API, logs in with a
+// browser, then screenshots the target (a dashboard, a single card, or the visual editor) into /out.
+//
+// Fatal (non-zero exit): HA never ready, onboarding/login fails, no card renders, or the page throws
+// an uncaught JS error. Benign console warnings/errors from the HA frontend are recorded but do not
+// fail the run.
+import { chromium } from '@playwright/test'
+import { mkdir, writeFile } from 'node:fs/promises'
+
+const env = process.env
+const HA_URL = (env.HA_URL || 'http://homeassistant:8123').replace(/\/$/, '')
+const CLIENT = HA_URL + '/'
+const HA_USER = env.HA_USER || 'dev'
+const HA_PASS = env.HA_PASS || 'ha-live-dev'
+const HA_LANG = env.HA_LANG || 'en'
+const MODE = env.MODE || 'dashboard'
+const EDITOR_TYPE = env.EDITOR_TYPE || 'horizon-card'
+const OUT = env.OUT || '/out'
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const log = (msg) => console.log(`[driver] ${msg}`)
+
+async function waitForHomeAssistant () {
+  for (let i = 0; i < 90; i++) {
+    try {
+      const res = await fetch(`${HA_URL}/api/onboarding`)
+      if (res.status === 200) { return res.json() }
+    } catch { /* not up yet */ }
+    await sleep(2000)
+  }
+  throw new Error('Home Assistant did not become ready within ~180s')
+}
+
+// Finish onboarding headlessly. HA only marks the instance onboarded once user, core_config,
+// analytics AND integration are all done; a fresh browser login otherwise lands on the wizard.
+async function onboard (steps) {
+  if (steps.every((step) => step.done)) { log('already onboarded'); return }
+
+  const userRes = await fetch(`${HA_URL}/api/onboarding/users`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ client_id: CLIENT, name: 'Dev', username: HA_USER, password: HA_PASS, language: HA_LANG })
+  })
+  if (!userRes.ok) { throw new Error(`onboarding/users -> HTTP ${userRes.status}`) }
+  const user = await userRes.json()
+  if (!user.auth_code) { throw new Error('onboarding/users returned no auth_code') }
+
+  const tokenRes = await fetch(`${HA_URL}/auth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: 'authorization_code', code: user.auth_code, client_id: CLIENT })
+  })
+  if (!tokenRes.ok) { throw new Error(`auth/token -> HTTP ${tokenRes.status}`) }
+  const token = await tokenRes.json()
+  if (!token.access_token) { throw new Error('auth/token returned no access_token') }
+
+  const headers = { Authorization: `Bearer ${token.access_token}`, 'Content-Type': 'application/json' }
+  const finalSteps = [
+    ['/api/onboarding/core_config', '{}'],
+    ['/api/onboarding/analytics', '{}'],
+    ['/api/onboarding/integration', JSON.stringify({ client_id: CLIENT, redirect_uri: `${CLIENT}?auth_callback=1` })]
+  ]
+  for (const [path, body] of finalSteps) {
+    const res = await fetch(`${HA_URL}${path}`, { method: 'POST', headers, body })
+    if (!res.ok) { throw new Error(`${path} -> HTTP ${res.status}`) }
+  }
+  log('onboarding complete')
+}
+
+async function login (page) {
+  await page.goto(HA_URL, { waitUntil: 'domcontentloaded' })
+  // The login form lives in the frontend's shadow DOM; Playwright locators pierce open shadow roots.
+  // These accessible names are the English labels (context locale is en-US, onboarding language en);
+  // they would need adjusting for a Home Assistant version that renamed them or a non-en language.
+  await page.getByRole('textbox', { name: 'Username' }).fill(HA_USER)
+  await page.getByRole('textbox', { name: 'Password' }).fill(HA_PASS)
+  await page.getByRole('button', { name: 'Log in' }).click()
+  // Wait until the dashboard shell is up.
+  await page.locator('home-assistant').waitFor({ state: 'attached', timeout: 30000 })
+  await page.waitForFunction(() => !location.pathname.startsWith('/auth'), null, { timeout: 30000 })
+}
+
+async function screenshotDashboard (page, report) {
+  // Wait for at least one card of ours to render (fatal if none appears).
+  await page.locator(`${EDITOR_TYPE}`).first().waitFor({ state: 'attached', timeout: 30000 })
+  await sleep(1500) // let the two-phase graph calculation settle
+
+  const full = `${OUT}/00-dashboard.png`
+  await page.screenshot({ path: full, fullPage: true })
+  report.screenshots.push(full)
+  log(`wrote ${full}`)
+
+  // Per-card screenshots are best-effort: a slicing failure must not fail the run.
+  try {
+    const cards = page.locator('hui-view hui-card')
+    const count = await cards.count()
+    for (let i = 0; i < count; i++) {
+      const card = cards.nth(i)
+      if (!(await card.isVisible())) { continue }
+      const file = `${OUT}/${String(i + 1).padStart(2, '0')}-card.png`
+      await card.screenshot({ path: file })
+      report.screenshots.push(file)
+    }
+    log(`wrote ${count} per-card screenshots`)
+  } catch (err) {
+    report.warnings.push(`per-card screenshots skipped: ${err.message}`)
+  }
+}
+
+async function screenshotEditor (page, report) {
+  // The card resource is loaded (a card of this type is on the dashboard), so getConfigElement is
+  // defined. Mount the editor with the live hass and expand every section, then screenshot it.
+  const mounted = await page.evaluate(async (type) => {
+    const ctor = customElements.get(type)
+    if (!ctor || typeof ctor.getConfigElement !== 'function') {
+      return { ok: false, reason: `${type} has no getConfigElement (bundle without an editor?)` }
+    }
+    const ha = document.querySelector('home-assistant')
+    const editor = await ctor.getConfigElement()
+    const container = document.createElement('div')
+    container.id = 'ha-live-editor'
+    container.style.cssText = 'position:fixed;top:0;left:0;z-index:99999;width:400px;padding:16px;' +
+      'background:var(--card-background-color,#fff);color:var(--primary-text-color,#000);box-sizing:border-box;'
+    container.appendChild(editor)
+    document.body.appendChild(container)
+    editor.hass = ha && ha.hass
+    editor.setConfig({ type: `custom:${type}` })
+    return { ok: true }
+  }, EDITOR_TYPE)
+
+  if (!mounted.ok) { throw new Error(mounted.reason) }
+  await sleep(2000) // let ha-form lazy-load its selectors
+
+  // Expand any collapsible sections so the whole form is visible.
+  await page.evaluate(() => {
+    const editor = document.querySelector('#ha-live-editor *')
+    const form = editor && editor.shadowRoot && editor.shadowRoot.querySelector('ha-form')
+    if (!form || !form.shadowRoot) { return }
+    form.shadowRoot.querySelectorAll('ha-form-expandable').forEach((exp) => {
+      const panel = exp.shadowRoot && exp.shadowRoot.querySelector('ha-expansion-panel')
+      if (panel) { panel.expanded = true }
+    })
+  })
+  await sleep(1000)
+
+  const file = `${OUT}/editor.png`
+  await page.locator('#ha-live-editor').screenshot({ path: file })
+  report.screenshots.push(file)
+  log(`wrote ${file}`)
+}
+
+async function main () {
+  await mkdir(OUT, { recursive: true })
+  const report = { mode: MODE, haUrl: HA_URL, screenshots: [], pageErrors: [], consoleErrors: [], warnings: [] }
+
+  log('waiting for Home Assistant...')
+  const steps = await waitForHomeAssistant()
+  await onboard(steps)
+
+  const browser = await chromium.launch({ args: ['--no-sandbox', '--disable-dev-shm-usage'] })
+  const context = await browser.newContext({ locale: 'en-US', viewport: { width: 1280, height: 900 } })
+  const page = await context.newPage()
+  page.on('pageerror', (err) => report.pageErrors.push(String(err.message || err)))
+  page.on('console', (msg) => { if (msg.type() === 'error') { report.consoleErrors.push(msg.text()) } })
+
+  try {
+    log('logging in...')
+    await login(page)
+    if (MODE === 'editor') {
+      await screenshotEditor(page, report)
+    } else {
+      await screenshotDashboard(page, report)
+    }
+  } finally {
+    await writeFile(`${OUT}/report.json`, JSON.stringify(report, null, 2))
+    await browser.close()
+  }
+
+  if (report.pageErrors.length > 0) {
+    log(`FAIL: ${report.pageErrors.length} uncaught page error(s):`)
+    report.pageErrors.forEach((e) => log(`  ${e}`))
+    process.exit(1)
+  }
+  log(`OK: ${report.screenshots.length} screenshot(s) in ${OUT}`)
+  if (report.consoleErrors.length > 0) { log(`(${report.consoleErrors.length} benign console error(s) recorded in report.json)`) }
+}
+
+main().catch((err) => { console.error(`[driver] ${err.stack || err}`); process.exit(1) })

--- a/dev/ha-live/verify.sh
+++ b/dev/ha-live/verify.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# dev/ha-live/verify.sh - bring up a real Home Assistant, load a Lovelace artifact of this card
+# (a dashboard, a single card, or the visual editor), and screenshot it headless. Docker only, so
+# nothing (Home Assistant, node, browsers) is installed on the host. Not part of CI. See README.md.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+MODE="dashboard"
+TARGET="$ROOT/tests/manual/styling-and-embedding.yaml"
+EDITOR_TYPE="horizon-card"
+OUT="$HERE/out"
+HA_VERSION=""
+KEEP=0
+HA_USER="dev"
+HA_PASS="ha-live-dev"
+RESOURCES=()
+
+die () { echo "error: $*" >&2; exit 1; }
+
+usage () {
+  cat >&2 <<'USAGE'
+Usage: dev/ha-live/verify.sh [options]
+  --dashboard <path>    Render a Lovelace dashboard YAML
+                        (default: tests/manual/styling-and-embedding.yaml)
+  --card <path>         Render a single card config (YAML), wrapped in a one-card dashboard
+  --editor [<type>]     Screenshot the card's visual editor (default type: horizon-card;
+                        needs a bundle that ships getConfigElement)
+  --resource url[,type] Extra Lovelace resource, e.g. Uix (repeatable; default type: module)
+  --ha-version <tag>    Home Assistant image tag to use (default: the pinned one)
+  --out <dir>           Screenshot output directory (default: dev/ha-live/out)
+  --keep                Leave HA running and publish http://localhost:8123 for manual inspection
+USAGE
+  exit 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dashboard) [ $# -ge 2 ] || usage; MODE="dashboard"; TARGET="$2"; shift 2 ;;
+    --card) [ $# -ge 2 ] || usage; MODE="card"; TARGET="$2"; shift 2 ;;
+    --editor)
+      MODE="editor"; shift
+      # An optional type argument follows only if it is not another flag.
+      case "${1:-}" in ''|-*) : ;; *) EDITOR_TYPE="$1"; shift ;; esac ;;
+    --resource) [ $# -ge 2 ] || usage; RESOURCES+=("$2"); shift 2 ;;
+    --ha-version) [ $# -ge 2 ] || usage; HA_VERSION="$2"; shift 2 ;;
+    --out) [ $# -ge 2 ] || usage; OUT="$2"; shift 2 ;;
+    --keep) KEEP=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+command -v docker >/dev/null 2>&1 || die "docker not found"
+docker info >/dev/null 2>&1 || die "docker daemon not running"
+
+# Resolve the output dir to an absolute path: docker treats a relative -v source as a NAMED VOLUME,
+# which would silently swallow the screenshots instead of writing them to the host.
+mkdir -p "$OUT" || die "cannot create output dir: $OUT"
+OUT="$(cd "$OUT" && pwd)"
+
+IMAGE="horizon-card-visual"
+NETWORK="ha-live_default"
+# -p pins the project name (so it wins over any exported COMPOSE_PROJECT_NAME), keeping the network
+# name that the driver joins deterministic.
+COMPOSE=(docker compose -p ha-live -f "$HERE/docker-compose.yml")
+[ "$KEEP" = 1 ] && COMPOSE+=(-f "$HERE/docker-compose.keep.yml")
+[ -z "$HA_VERSION" ] || export HA_IMAGE="ghcr.io/home-assistant/home-assistant:$HA_VERSION"
+
+cleanup () {
+  code=$?
+  # Only leave HA running on a clean run; on a failed start, tear the partial stack down instead of
+  # printing a misleading "it's running" banner.
+  if [ "$KEEP" = 1 ] && [ "$code" -eq 0 ]; then
+    echo ""
+    echo "[ha-live] left running (--keep):  http://localhost:8123   user '$HA_USER'   pass '$HA_PASS'"
+    echo "[ha-live] stop it with:  ${COMPOSE[*]} down"
+  else
+    "${COMPOSE[@]}" down >/dev/null 2>&1 || true
+    [ "$KEEP" = 1 ] && echo "[ha-live] startup failed; nothing left running." >&2
+  fi
+  exit $code
+}
+trap cleanup EXIT
+
+CFG="$HERE/config"
+
+echo "[ha-live] building image (card bundle + Playwright)..."
+docker build -q -f "$ROOT/docker/Dockerfile.visual" -t "$IMAGE" "$ROOT" >/dev/null
+
+# A clean config each run: onboarding is one-shot, so a persisted .storage would make the next run
+# unable to create the dev user. verify.sh regenerates everything here from scratch.
+echo "[ha-live] preparing a clean Home Assistant config..."
+rm -rf "$CFG"
+mkdir -p "$CFG/www" "$OUT"
+docker run --rm -v "$CFG/www:/copyout" "$IMAGE" sh -lc "cp dist/lovelace-horizon-card.js /copyout/"
+
+{
+  echo "default_config:"
+  echo "lovelace:"
+  echo "  mode: yaml"
+  echo "  resources:"
+  echo "    - url: /local/lovelace-horizon-card.js"
+  echo "      type: module"
+} > "$CFG/configuration.yaml"
+if [ ${#RESOURCES[@]} -gt 0 ]; then
+  for res in "${RESOURCES[@]}"; do
+    url="${res%%,*}"
+    rtype="module"
+    case "$res" in *,*) rtype="${res#*,}" ;; esac
+    [ -n "$rtype" ] || rtype="module"
+    printf '    - url: %s\n      type: %s\n' "$url" "$rtype" >> "$CFG/configuration.yaml"
+  done
+fi
+
+# The target dashboard for YAML-mode Lovelace: fresh login lands directly on it (Overview).
+case "$MODE" in
+  dashboard)
+    [ -f "$TARGET" ] || die "dashboard file not found: $TARGET"
+    cp "$TARGET" "$CFG/ui-lovelace.yaml"
+    ;;
+  card)
+    [ -f "$TARGET" ] || die "card file not found: $TARGET"
+    {
+      echo "title: HA Live"
+      echo "views:"
+      echo "  - title: Card"
+      echo "    cards:"
+      echo "      -"
+      sed 's/^/        /' "$TARGET"
+    } > "$CFG/ui-lovelace.yaml"
+    ;;
+  editor)
+    # A card of this type makes the frontend load the resource so getConfigElement is defined; the
+    # driver mounts the editor itself.
+    {
+      echo "title: HA Live"
+      echo "views:"
+      echo "  - title: Editor"
+      echo "    cards:"
+      echo "      - type: custom:$EDITOR_TYPE"
+    } > "$CFG/ui-lovelace.yaml"
+    ;;
+esac
+
+echo "[ha-live] starting Home Assistant..."
+"${COMPOSE[@]}" up -d
+
+echo "[ha-live] running the Playwright driver..."
+if docker run --rm --network "$NETWORK" \
+  -v "$HERE/driver.mjs:/app/driver.mjs:ro" \
+  -v "$OUT:/out" \
+  -e HA_URL="http://homeassistant:8123" \
+  -e HA_USER="$HA_USER" -e HA_PASS="$HA_PASS" \
+  -e MODE="$MODE" -e EDITOR_TYPE="$EDITOR_TYPE" -e OUT="/out" \
+  "$IMAGE" node /app/driver.mjs
+then
+  echo "[ha-live] done. Screenshots in: $OUT"
+else
+  echo "[ha-live] driver failed. Recent Home Assistant logs:" >&2
+  "${COMPOSE[@]}" logs --tail 40 homeassistant >&2 || true
+  exit 1
+fi

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -4,6 +4,14 @@ Lovelace dashboards for checking the card visually in a real Home Assistant,
 covering cases the automated `unit/` and `visual/` suites cannot: Uix / card-mod
 styling, embedding, stacks and theme interaction.
 
+You do not have to load these by hand. [`dev/ha-live/verify.sh`](../../dev/ha-live/README.md) renders
+any of them (or a single card, or the visual editor) in a throwaway real Home Assistant: it brings up
+a pinned Home Assistant in Docker, installs the built card, and screenshots the result. For example:
+
+```bash
+dev/ha-live/verify.sh --dashboard tests/manual/styling-and-embedding.yaml
+```
+
 ## `styling-and-embedding.yaml`
 
 A single dashboard view that shows the card's styling, embedding and options:

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -12,6 +12,9 @@ a pinned Home Assistant in Docker, installs the built card, and screenshots the 
 dev/ha-live/verify.sh --dashboard tests/manual/styling-and-embedding.yaml
 ```
 
+The screenshots (and a `report.json`) land in `dev/ha-live/out/`, which is git-ignored and
+regenerated on each run.
+
 ## `styling-and-embedding.yaml`
 
 A single dashboard view that shows the card's styling, embedding and options:


### PR DESCRIPTION
## What

A local dev capability, `dev/ha-live/`, that brings up a real (pinned) Home Assistant in Docker, installs the built card, loads a Lovelace artifact, screenshots it headless, then tears down. Docker only, so nothing (Home Assistant, node, browsers) is installed on the host. Not part of CI.

It turns the by-hand ritual in [`tests/manual/README.md`](tests/manual/README.md) (build, add the resource, install Uix, paste the 755-line dashboard into the Raw configuration editor) into one command.

## Usage

```bash
dev/ha-live/verify.sh                          # the manual test dashboard (default)
dev/ha-live/verify.sh --dashboard x.yaml       # any dashboard YAML
dev/ha-live/verify.sh --card card.yaml         # a single card config
dev/ha-live/verify.sh --editor                 # the card's visual editor
dev/ha-live/verify.sh --resource /local/uix.js # also load Uix so the styling cards apply their mods
dev/ha-live/verify.sh --keep                   # leave HA up on localhost:8123 to click around
```

Screenshots and a `report.json` (mode, files, any uncaught page errors, recorded console errors) land in `dev/ha-live/out/`.

## How it works

- **All YAML-mode Lovelace**: one mechanism loads the card resource for every target, and nothing is hand-seeded into `.storage`.
- **No host port by default**: the Playwright driver reaches HA over the compose network, so it never collides with a Home Assistant you already run on 8123. `--keep` publishes it for manual inspection.
- The driver waits for HA, finishes onboarding over the API, logs in, and screenshots the target. It fails on an uncaught page error, a failed login, or no card rendering; benign HA console warnings are only recorded.
- `config/` is regenerated from scratch each run (onboarding is one-shot) and is git-ignored.

## Verified

Dogfooded: `verify.sh` against the manual dashboard brings up HA, renders it, and writes **142 screenshots** (the full view plus 141 per-card) with **0 page errors and 0 console errors**, then tears down with no leftover containers or networks.

## Relation to the visual editor (#41 / #235)

This generalises the real-Home-Assistant check first built for the visual editor. That PR's own `dev/ha-editor-verify/` is being removed in favour of the `--editor` preset here. (`--editor` needs a bundle that ships `getConfigElement`, so it is exercised once the editor is in the build, not on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
